### PR TITLE
Adding 'alias' field that will be used as the class attribute for <li> tags generated in menu construct

### DIFF
--- a/config/schema/schema.php
+++ b/config/schema/schema.php
@@ -158,7 +158,7 @@ class AppSchema extends CakeSchema {
 	var $menus = array(
 		'id' => array('type' => 'integer', 'null' => false, 'default' => NULL, 'length' => 10, 'key' => 'primary'),
 		'title' => array('type' => 'string', 'null' => false, 'default' => NULL, 'collate' => 'utf8_unicode_ci', 'charset' => 'utf8'),
-		'alias' => array('type' => 'string', 'null' => false, 'default' => NULL, 'key' => 'unique', 'collate' => 'utf8_unicode_ci', 'charset' => 'utf8'),
+		'class' => array('type' => 'string', 'null' => false, 'default' => NULL, 'key' => 'unique', 'collate' => 'utf8_unicode_ci', 'charset' => 'utf8'),
 		'description' => array('type' => 'text', 'null' => true, 'default' => NULL, 'collate' => 'utf8_unicode_ci', 'charset' => 'utf8'),
 		'status' => array('type' => 'boolean', 'null' => false, 'default' => '1'),
 		'weight' => array('type' => 'integer', 'null' => true, 'default' => NULL),

--- a/config/schema/sql/croogo.sql
+++ b/config/schema/sql/croogo.sql
@@ -189,7 +189,7 @@ CREATE TABLE IF NOT EXISTS `links` (
   `parent_id` int(20) DEFAULT NULL,
   `menu_id` int(20) NOT NULL,
   `title` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
-  `alias` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+  `class` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
   `description` text COLLATE utf8_unicode_ci,
   `link` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
   `target` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,

--- a/config/schema/sql/croogo_data.sql
+++ b/config/schema/sql/croogo_data.sql
@@ -267,7 +267,7 @@ INSERT IGNORE INTO `languages` (`id`, `title`, `native`, `alias`, `status`, `wei
 -- Dumping data for table `links`
 --
 
-INSERT IGNORE INTO `links` (`id`, `parent_id`, `menu_id`, `title`, `alias`, `description`, `link`, `target`, `rel`, `status`, `lft`, `rght`, `visibility_roles`, `params`, `updated`, `created`) VALUES
+INSERT IGNORE INTO `links` (`id`, `parent_id`, `menu_id`, `title`, `class`, `description`, `link`, `target`, `rel`, `status`, `lft`, `rght`, `visibility_roles`, `params`, `updated`, `created`) VALUES
 (5, NULL, 4, 'About', 'about', '', 'controller:nodes/action:view/type:page/slug:about', '', '', 1, 3, 4, '', '', '2009-10-06 23:14:21', '2009-08-19 12:23:33'),
 (6, NULL, 4, 'Contact', 'contact', '', 'controller:contacts/action:view/contact', '', '', 1, 5, 6, '', '', '2009-10-06 23:14:45', '2009-08-19 12:34:56'),
 (7, NULL, 3, 'Home', 'home', '', '/', '', '', 1, 5, 6, '', '', '2009-10-06 21:17:06', '2009-09-06 21:32:54'),

--- a/views/helpers/layout.php
+++ b/views/helpers/layout.php
@@ -351,7 +351,7 @@ class LayoutHelper extends AppHelper {
             if (isset($link['children']) && count($link['children']) > 0) {
                 $linkOutput .= $this->nestedLinks($link['children'], $options, $depth + 1);
             }
-            $linkOutput = $this->Html->tag('li', $linkOutput, array('class' => $link['Link']['alias']));
+            $linkOutput = $this->Html->tag('li', $linkOutput, array('class' => $link['Link']['class']));
             $output .= $linkOutput;
         }
         if ($output != null) {

--- a/views/links/admin_add.ctp
+++ b/views/links/admin_add.ctp
@@ -20,7 +20,7 @@
                             'empty' => true,
                         ));
                         echo $this->Form->input('title');
-                        echo $this->Form->input('alias', array('class' => 'alias'));
+                        echo $this->Form->input('class', array('class' => 'class'));
                         echo $this->Form->input('link') .
                             $this->Html->link(__('Link to a Node', true), Router::url(array(
                                 'controller' => 'nodes',

--- a/views/links/admin_edit.ctp
+++ b/views/links/admin_edit.ctp
@@ -21,7 +21,7 @@
                             'empty' => true,
                         ));
                         echo $this->Form->input('title');
-                        echo $this->Form->input('alias', array('class' => 'alias'));
+                        echo $this->Form->input('class', array('class' => 'class'));
                         echo $this->Form->input('link') . 
                             $this->Html->link(__('Link to a Node', true), Router::url(array(
                                 'controller' => 'nodes',

--- a/webroot/js/links.js
+++ b/webroot/js/links.js
@@ -12,7 +12,7 @@ var Links = {};
  */
 Links.slug = function() {
     $("#LinkTitle").slug({
-        slug: 'alias',
+        slug: 'class',
         hide: false
     });
 }


### PR DESCRIPTION
- The 'alias' field is used as class for '<li>' element in menus
  Useful for menu with icons
- Adjusted /admin/links/[add|edit] to display/edit alias
