### PR TITLE
Ui.tabs broken on nodes/admin_add for tabs named "Foo / Bar"

### DIFF
--- a/views/helpers/layout.php
+++ b/views/helpers/layout.php
@@ -683,7 +683,7 @@ class LayoutHelper extends AppHelper {
         if (is_array($tabs)) {
             foreach ($tabs AS $title => $tab) {
                 if (!isset($tab['options']['type']) || (isset($tab['options']['type']) && (in_array($this->View->viewVars['typeAlias'], $tab['options']['type'])))) {
-                    $domId = strtolower(Inflector::singularize($this->params['controller'])) . '-' . strtolower($title);
+                    $domId = strtolower(Inflector::singularize($this->params['controller'])) . '-' . strtolower(Inflector::slug($title, '-'));
                     if ($this->adminTabs) {
                         if (strstr($tab['element'], '.')) {
                             $elementE = explode('.', $tab['element']);


### PR DESCRIPTION
Modified dom id generation algorithm to better deal with tab names (like "Foo / Bar") without breaking ui.tabs
