### PR TITLE
Minor updates to CroogoShell

### DIFF
--- a/Console/Command/CroogoShell.php
+++ b/Console/Command/CroogoShell.php
@@ -13,7 +13,9 @@
  */
 App::uses('Security', 'Utility');
 class CroogoShell extends AppShell {
-
+/**
+ * Display help/options
+ */
 	public function getOptionParser() {
 		$parser = parent::getOptionParser();
 		$parser->description(__d('croogo', 'Croogo Utilities')
@@ -36,7 +38,7 @@ class CroogoShell extends AppShell {
 /**
  * Get hashed password
  *
- * Usage: ./cake croogo password myPasswordHere
+ * Usage: ./Console/cake croogo password myPasswordHere
  */
 	public function password() {
 		$value = trim($this->args['0']);
@@ -44,9 +46,9 @@ class CroogoShell extends AppShell {
 	}
 
 /**
- * Prepares data in config/schema/data/ required for install plugin
+ * Prepares data in Config/Schema/data/ required for install plugin
  *
- * Usage: ./cake croogo data table_name_here
+ * Usage: ./Console/cake croogo data table_name_here
  */
 	public function data() {
 		$connection = 'default';
@@ -82,7 +84,7 @@ class CroogoShell extends AppShell {
 			$content .= "}\n";
 
 		// write file
-		$filePath = APP . 'config' . DS . 'schema' . DS . 'data' . DS . Inflector::underscore($modelAlias) . '_data.php';
+		$filePath = APP . 'Config' . DS . 'Schema' . DS . 'data' . DS . Inflector::underscore($modelAlias) . '_data.php';
 		if (!file_exists($filePath)) {
 			touch($filePath);
 		}


### PR DESCRIPTION
I missed the spaces to tabs in the CroogoShell. This also corrects the folder location for the `./Console/cake croogo data' command.

But... is the `data` subcommand even needed? It seems to generate a fixture that can be done by the CakePHP core instead. Let me know and I'll update this pull.
