### PR TITLE
1.4 routable content types

### DIFF
--- a/Config/croogo_routes.php
+++ b/Config/croogo_routes.php
@@ -11,6 +11,7 @@
 	// Content types
 	CroogoRouter::contentType('blog');
 	CroogoRouter::contentType('node');
+	CroogoRouter::routableContentTypes();
 	
 	// Page
 	CroogoRouter::connect('/about', array('controller' => 'nodes', 'action' => 'view', 'type' => 'page', 'slug' => 'about'));

--- a/Lib/CroogoRouter.php
+++ b/Lib/CroogoRouter.php
@@ -82,4 +82,23 @@ class CroogoRouter {
 		CroogoRouter::connect('/' . $alias . '/:slug', array('controller' => 'nodes', 'action' => 'view', 'type' => $alias));
 		CroogoRouter::connect('/' . $alias . '/term/:slug/*', array('controller' => 'nodes', 'action' => 'term', 'type' => $alias));
 	}
+
+/**
+ * Apply routes for content types with routes enabled
+ * 
+ * @return void
+ */
+	public static function routableContentTypes() {
+		$types = ClassRegistry::init('Type')->find('all', array(
+			'cache' => array(
+				'name' => 'croogo_types',
+				'config' => 'croogo_types',
+			),
+		));
+		foreach ($types as $type) {
+			if (isset($type['Params']['routes']) && $type['Params']['routes']) {
+				CroogoRouter::contentType($type['Type']['alias']);
+			}
+		}
+	}
 }


### PR DESCRIPTION
## The problem

If admin creates new content types, they end up having URLs like `/nodes/view/type:foo/slug:bar`

The only way to have beautiful URLs is to edit the routes file manually.
## The solution

Allow users to specify which content types they want to have beautiful URLs via the Params field when adding/editing content types.

This will result in URLs like `/foo/bar`
## Usage

When adding/editing content types, go to Params tab, and enter:

```
routes=1
```
