### PR TITLE
1.4 comments

### DIFF
--- a/Controller/CommentsController.php
+++ b/Controller/CommentsController.php
@@ -181,8 +181,16 @@ class CommentsController extends AppController {
 		}
 		$type = $this->Comment->Node->Taxonomy->Vocabulary->Type->findByAlias($node['Node']['type']);
 		$continue = false;
-		if ($type['Type']['comment_status'] && $node['Node']['comment_status']) {
+		if ($type['Type']['comment_status'] == 2 && $node['Node']['comment_status']) {
 			$continue = true;
+		} else {
+			$this->Session->setFlash(__('Comments are not allowed.'), 'default', array('class' => 'error'));
+			$this->redirect(array(
+				'controller' => 'nodes',
+				'action' => 'view',
+				'type' => $node['Node']['type'],
+				'slug' => $node['Node']['slug'],
+			));
 		}
 
 		// spam protection and captcha


### PR DESCRIPTION
## The problem

Those who know the URL for posting comments, can post comments to nodes whose content types have comments disabled or read-only.
## To reproduce
- Create a new content Type
- Create a new Node of that Type
- Disable comments (or make read-only) in Type settings
- Visit /comments/add/123 (where 123 is the Node ID)

Visitor will be able to post comments.
## Fix

Check if Type has comments in read/write mode before processing `CommentsController::add()` any further.
