### PR TITLE
Make custom validation methods public

### DIFF
--- a/Model/AppModel.php
+++ b/Model/AppModel.php
@@ -223,17 +223,37 @@ class AppModel extends Model {
 /**
  * Validation method for alias field
  * @return bool true when validation successful
+ * @deprecated Protected validation methods are no longer supported
  */
 	protected function _validAlias($check) {
-		return preg_match('/^[\p{Ll}\p{Lm}\p{Lo}\p{Lt}\p{Lu}\p{Nd}-_]+$/mu', $check[key($check)]);
+		return $this->validAlias($check);
 	}
 
 /**
  * Validation method for name or title fields
  * @return bool true when validation successful
+ * @deprecated Protected validation methods are no longer supported
  */
 	protected function _validName($check) {
-		return preg_match('/^[\p{Ll}\p{Lm}\p{Lo}\p{Lt}\p{Lu}\p{Nd}-_\[\]\(\) ]+$/mu', $check[key($check)]);
+		return $this->validName($check);
+	}
+
+/**
+ * Validation method for alias field
+ *
+ * @return bool true when validation successful
+ */
+	public function validAlias($check) {
+		return (preg_match('/^[\p{Ll}\p{Lm}\p{Lo}\p{Lt}\p{Lu}\p{Nd}-_]+$/mu', $check[key($check)]) == 1);
+	}
+
+/**
+ * Validation method for name or title fields
+ *
+ * @return bool true when validation successful
+ */
+	public function validName($check) {
+		return (preg_match('/^[\p{Ll}\p{Lm}\p{Lo}\p{Lt}\p{Lu}\p{Nd}-_\[\]\(\) ]+$/mu', $check[key($check)]) == 1);
 	}
 
 }

--- a/Model/Role.php
+++ b/Model/Role.php
@@ -48,7 +48,7 @@ class Role extends AppModel {
 				'last' => true,
 			),
 			'validName' => array(
-				'rule' => '_validName',
+				'rule' => 'validName',
 				'message' => 'This field must be alphanumeric',
 				'last' => true,
 			),
@@ -65,7 +65,7 @@ class Role extends AppModel {
 				'last' => true,
 			),
 			'validAlias' => array(
-				'rule' => '_validAlias',
+				'rule' => 'validAlias',
 				'message' => 'This field must be alphanumeric',
 				'last' => true,
 			),

--- a/Model/User.php
+++ b/Model/User.php
@@ -72,7 +72,7 @@ class User extends AppModel {
 				'last' => true,
 			),
 			'validAlias' => array(
-				'rule' => '_validAlias',
+				'rule' => 'validAlias',
 				'message' => 'This field must be alphanumeric',
 				'last' => true,
 			),
@@ -94,7 +94,7 @@ class User extends AppModel {
 			'message' => 'Passwords must be at least 6 characters long.',
 		),
 		'verify_password' => array(
-			'rule' => '_identical',
+			'rule' => 'validIdentical',
 		),
 		'name' => array(
 			'notEmpty' => array(
@@ -103,7 +103,7 @@ class User extends AppModel {
 				'last' => true,
 			),
 			'validName' => array(
-				'rule' => '_validName',
+				'rule' => 'validName',
 				'message' => 'This field must be alphanumeric',
 				'last' => true,
 			),
@@ -145,6 +145,12 @@ class User extends AppModel {
 		'status',
 	);
 
+/**
+ * beforeDelete
+ *
+ * @param boolean $cascade
+ * @return boolean
+ */
 	public function beforeDelete($cascade = true) {
 		$this->Role->Behaviors->attach('Aliasable');
 		$adminRoleId = $this->Role->byAlias('admin');
@@ -166,6 +172,12 @@ class User extends AppModel {
 		return true;
 	}
 
+/**
+ * beforeSave
+ *
+ * @param array $options
+ * @return boolean
+ */
 	public function beforeSave($options = array()) {
 		if (!empty($this->data['User']['password'])) {
 			$this->data['User']['password'] = AuthComponent::password($this->data['User']['password']);
@@ -173,7 +185,24 @@ class User extends AppModel {
 		return true;
 	}
 
+/**
+ * _identical
+ *
+ * @param string $check
+ * @return boolean
+ * @deprecated Protected validation methods are no longer supported
+ */
 	protected function _identical($check) {
+		return $this->validIdentical($check);
+	}
+
+/**
+ * validIdentical
+ *
+ * @param string $check
+ * @return boolean
+ */
+	public function validIdentical($check) {
 		if (isset($this->data['User']['password'])) {
 			if ($this->data['User']['password'] != $check['verify_password']) {
 				return __('Passwords do not match. Please, try again.');

--- a/Test/Case/Model/AppModelTest.php
+++ b/Test/Case/Model/AppModelTest.php
@@ -1,0 +1,80 @@
+<?php
+App::uses('CroogoTestCase', 'TestSuite');
+App::uses('Model', 'Model');
+App::uses('AppModel', 'Model');
+App::uses('User', 'Model');
+App::uses('AuthComponent', 'Controller/Component');
+App::uses('CroogoTestCase', 'TestSuite');
+
+/**
+ * AppModelTest file
+ *
+ * This file is to test the AppModel
+ *
+ * @category Test
+ * @package  Croogo
+ * @version  1.0
+ * @author   Fahad Ibnay Heylaal <contact@fahad19.com>
+ * @license  http://www.opensource.org/licenses/mit-license.php The MIT License
+ * @link     http://www.croogo.org
+ */
+class AppModelTest extends CroogoTestCase {
+
+/**
+ * Fixtures
+ *
+ * @var array
+ */
+	public $fixtures = array(
+		'app.aco',
+		'app.aro',
+		'app.aros_aco',
+		'app.role',
+		'app.user',
+		'app.setting',
+	);
+
+/**
+ * User instance
+ *
+ * @var TestUser
+ */
+	public $User;
+
+/**
+ * setUp method
+ *
+ * @return void
+ */
+	public function setUp() {
+		parent::setUp();
+		$this->User = ClassRegistry::init('User');
+	}
+
+/**
+ * tearDown method
+ *
+ * @return void
+ */
+	public function tearDown() {
+		parent::tearDown();
+		unset($this->User);
+	}
+
+/**
+ * testValidName
+ */
+	public function testValidName() {
+		$this->assertTrue($this->User->validName(array('name' => 'Kyle')));
+		$this->assertFalse($this->User->validName(array('name' => 'what%is@this#i*dont!even')));
+	}
+
+/**
+ * testValidAlias
+ */
+	public function testValidAlias() {
+		$this->assertTrue($this->User->validAlias(array('name' => 'Kyle')));
+		$this->assertFalse($this->User->validAlias(array('name' => 'Not an Alias')));
+	}
+
+}

--- a/Test/Case/Model/UserTest.php
+++ b/Test/Case/Model/UserTest.php
@@ -3,7 +3,6 @@ App::uses('CroogoTestCase', 'TestSuite');
 App::uses('Model', 'Model');
 App::uses('AppModel', 'Model');
 App::uses('User', 'Model');
-App::uses('AppModel', 'Model');
 App::uses('AuthComponent', 'Controller/Component');
 App::uses('CroogoTestCase', 'TestSuite');
 
@@ -19,16 +18,6 @@ class TestUser extends User {
  * @var string
  */
 	public $alias = 'User';
-
-/**
- * identical method
- *
- * @param array $check
- * @return boolean
- */
-	public function identical($check) {
-		return $this->_identical($check);
-	}
 
 }
 
@@ -119,15 +108,15 @@ class UserTest extends CroogoTestCase {
 	}
 
 /**
- * testIdentical method
+ * testValidIdenticalPassword method
  *
  * @return void
  */
-	public function testIdenticalPassword() {
+	public function testValidIdenticalPassword() {
 		$this->User->data['User'] = array('password' => '123456');
-		$this->assertTrue($this->User->identical(array('verify_password' => '123456')));
+		$this->assertTrue($this->User->validIdentical(array('verify_password' => '123456')));
 		$this->User->data['User'] = array('password' => '123456');
-		$this->assertContains('Passwords do not match. Please, try again.', $this->User->identical(array('verify_password' => 'other-value')));
+		$this->assertContains('Passwords do not match. Please, try again.', $this->User->validIdentical(array('verify_password' => 'other-value')));
 	}
 
 /**


### PR DESCRIPTION
With the 2.2 cake validator, **protected** custom validation methods won't work. This commit deprecates the protected methods and sets them up as public methods. It also moves `validAlias` and `validaName` out of the `AppModel` as they're only used by the `User` and `Role` model.
