### PR TITLE
1.4 install fix

### DIFF
--- a/Console/Command/InstallShell.php
+++ b/Console/Command/InstallShell.php
@@ -73,7 +73,7 @@ class InstallShell extends AppShell {
  */
 	public function main() {
 		$type = $this->args[0];
-		if (strpos($this->args[1], '/') !== false) {
+		if (strpos($this->args[1], '/') !== false && preg_match('/http[s]*:\/\//i', $this->args[1]) === 0) {
 			// Composer Install
 			$ver = isset($this->args[2]) ? $this->args[2] : '*';
 			$this->out(__('Installing with Composer...'));


### PR DESCRIPTION
There is a issue with the install shell when you try to install with a github url such as `cake install plugin https://github.com/shama/oven`. It will detect the `/` and wrongly think it's a composer url. This fixes this.
