### PR TITLE
Fix Nodes, Menus, Vocabulary block filters

### DIFF
--- a/Plugin/Blocks/Controller/Component/BlocksComponent.php
+++ b/Plugin/Blocks/Controller/Component/BlocksComponent.php
@@ -149,10 +149,9 @@ class BlocksComponent extends Component {
  * @return array
  */
 	public function parseString($exp, $text, $options = array()) {
-		$_options = array(
+		$options = array_merge(array(
 			'convertOptionsToArray' => false,
-		);
-		$options = array_merge($_options, $options);
+		), $options);
 
 		$output = array();
 		preg_match_all('/\[(' . $exp . '):([A-Za-z0-9_\-]*)(.*?)\]/i', $text, $tagMatches);

--- a/Plugin/Nodes/Test/Case/Controller/NodesControllerTest.php
+++ b/Plugin/Nodes/Test/Case/Controller/NodesControllerTest.php
@@ -2,6 +2,8 @@
 App::uses('NodesController', 'Nodes.Controller');
 App::uses('CroogoControllerTestCase', 'TestSuite');
 
+CakePlugin::load('Translate');
+
 class TestNodesController extends NodesController {
 
 	public $name = 'Nodes';
@@ -228,6 +230,20 @@ class NodesControllerTest extends CroogoControllerTestCase {
 
 		$result = $this->Nodes->viewFallback(array('view_1', 'view_blog'));
 		$this->assertContains('view_1.ctp in Mytheme', $result->body());
+	}
+
+/**
+ * Tests that blocks do not contain unfiltered block content
+ *
+ * @return void
+ */
+	public function testBlocksAreFiltered() {
+		$result = $this->testAction('/nodes/nodes/index', array(
+			'return' => 'contents',
+		));
+		$this->assertNotContains('[vocabulary:', $result);
+		$this->assertNotContains('[menu:', $result);
+		$this->assertNotContains('[node:', $result);
 	}
 
 }

--- a/View/Helper/LayoutHelper.php
+++ b/View/Helper/LayoutHelper.php
@@ -25,6 +25,9 @@ class LayoutHelper extends AppHelper {
 		'Form',
 		'Session',
 		'Js',
+		'Nodes.Nodes',
+		'Taxonomy.Taxonomies',
+		'Menus.Menus',
 	);
 
 /**
@@ -311,6 +314,9 @@ class LayoutHelper extends AppHelper {
 	public function filter($content) {
 		Croogo::dispatchEvent('Helper.Layout.beforeFilter', $this->_View, array('content' => &$content));
 		$content = $this->filterElements($content);
+		$content = $this->Nodes->filter($content);
+		$content = $this->Menus->filter($content);
+		$content = $this->Taxonomies->filter($content);
 		Croogo::dispatchEvent('Helper.Layout.afterFilter', $this->_View, array('content' => &$content));
 		return $content;
 	}


### PR DESCRIPTION
This fixes the blocks in 1.5 not being filtered.

Later, I want to refactor how blocks are processed. Currently there is a lot of logic duplication that should be put into the common libs.
