### PR TITLE
Fix Acl cache

### DIFF
--- a/Plugin/Acl/Controller/AclPermissionsController.php
+++ b/Plugin/Acl/Controller/AclPermissionsController.php
@@ -115,6 +115,7 @@ class AclPermissionsController extends AclAppController {
 			$parentAcoId = $this->AclPermission->Aco->field('parent_id');
 			$cacheName = 'permissions_aco_' . $parentAcoId;
 			Cache::delete($cacheName, 'permissions');
+			Cache::delete('permissions_public', 'permissions');
 		}
 
 		$this->set(compact('acoId', 'aroId', 'data', 'success', 'permitted'));


### PR DESCRIPTION
Bug : Change the permissions of group "Public" doesn't work. This can be tested with homepage of Croogo by changing permissions of "Nodes/Promoted".

Problem : Cache for Public group wasn't removed

Solution : remove the cache for the public group when permissions change
