### PR TITLE
Defaults to InnoDb storage engine for mysql

### DIFF
--- a/Plugin/Acl/Config/Migration/1346931401_firstmigrationacl.php
+++ b/Plugin/Acl/Config/Migration/1346931401_firstmigrationacl.php
@@ -29,7 +29,7 @@ class FirstMigrationAcl extends CakeMigration {
 					'indexes' => array(
 						'PRIMARY' => array('column' => 'id', 'unique' => 1)
 					),
-					'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+					'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 				),
 				'aros' => array(
 					'id' => array('type' => 'integer', 'null' => false, 'default' => null, 'length' => 10, 'key' => 'primary'),
@@ -42,7 +42,7 @@ class FirstMigrationAcl extends CakeMigration {
 					'indexes' => array(
 						'PRIMARY' => array('column' => 'id', 'unique' => 1)
 					),
-					'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+					'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 				),
 				'aros_acos' => array(
 					'id' => array('type' => 'integer', 'null' => false, 'default' => null, 'length' => 10, 'key' => 'primary'),
@@ -55,7 +55,7 @@ class FirstMigrationAcl extends CakeMigration {
 					'indexes' => array(
 						'PRIMARY' => array('column' => 'id', 'unique' => 1)
 					),
-					'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+					'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 				),
 			),
 		),

--- a/Plugin/Acl/Config/Schema/schema.php
+++ b/Plugin/Acl/Config/Schema/schema.php
@@ -19,7 +19,7 @@ class AclSchema extends CakeSchema {
 		'indexes' => array(
 			'PRIMARY' => array('column' => 'id', 'unique' => 1)
 		),
-		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 	);
 	public $aros = array(
 		'id' => array('type' => 'integer', 'null' => false, 'default' => null, 'length' => 10, 'key' => 'primary'),
@@ -32,7 +32,7 @@ class AclSchema extends CakeSchema {
 		'indexes' => array(
 			'PRIMARY' => array('column' => 'id', 'unique' => 1)
 		),
-		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 	);
 	public $aros_acos = array(
 		'id' => array('type' => 'integer', 'null' => false, 'default' => null, 'length' => 10, 'key' => 'primary'),
@@ -45,6 +45,6 @@ class AclSchema extends CakeSchema {
 		'indexes' => array(
 			'PRIMARY' => array('column' => 'id', 'unique' => 1)
 		),
-		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 	);
 }

--- a/Plugin/Blocks/Config/Migration/1346931401_firstmigrationblocks.php
+++ b/Plugin/Blocks/Config/Migration/1346931401_firstmigrationblocks.php
@@ -39,7 +39,7 @@ class FirstMigrationBlocks extends CakeMigration {
 						'PRIMARY' => array('column' => 'id', 'unique' => 1),
 						'block_alias' => array('column' => 'alias', 'unique' => 1)
 					),
-					'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+					'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 				),
 				'regions' => array(
 					'id' => array('type' => 'integer', 'null' => false, 'default' => null, 'key' => 'primary'),
@@ -51,7 +51,7 @@ class FirstMigrationBlocks extends CakeMigration {
 						'PRIMARY' => array('column' => 'id', 'unique' => 1),
 						'region_alias' => array('column' => 'alias', 'unique' => 1)
 					),
-					'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+					'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 				),
 			),
 		),

--- a/Plugin/Blocks/Config/Schema/schema.php
+++ b/Plugin/Blocks/Config/Schema/schema.php
@@ -29,7 +29,7 @@ class BlocksSchema extends CakeSchema {
 			'PRIMARY' => array('column' => 'id', 'unique' => 1),
 			'block_alias' => array('column' => 'alias', 'unique' => 1)
 		),
-		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 	);
 	public $regions = array(
 		'id' => array('type' => 'integer', 'null' => false, 'default' => null, 'key' => 'primary'),
@@ -41,6 +41,6 @@ class BlocksSchema extends CakeSchema {
 			'PRIMARY' => array('column' => 'id', 'unique' => 1),
 			'region_alias' => array('column' => 'alias', 'unique' => 1)
 		),
-		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 	);
 }

--- a/Plugin/Blocks/Test/Fixture/BlockFixture.php
+++ b/Plugin/Blocks/Test/Fixture/BlockFixture.php
@@ -22,7 +22,7 @@ class BlockFixture extends CroogoTestFixture {
 		'updated' => array('type' => 'datetime', 'null' => false, 'default' => null),
 		'created' => array('type' => 'datetime', 'null' => false, 'default' => null),
 		'indexes' => array('PRIMARY' => array('column' => 'id', 'unique' => 1), 'alias' => array('column' => 'alias', 'unique' => 1)),
-		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 	);
 
 	public $records = array(

--- a/Plugin/Blocks/Test/Fixture/RegionFixture.php
+++ b/Plugin/Blocks/Test/Fixture/RegionFixture.php
@@ -14,7 +14,7 @@ class RegionFixture extends CroogoTestFixture {
 			'PRIMARY' => array('column' => 'id', 'unique' => 1),
 			'region_alias' => array('column' => 'alias', 'unique' => 1),
 			),
-		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 	);
 
 	public $records = array(

--- a/Plugin/Comments/Config/Migration/1346931401_firstmigrationcomments.php
+++ b/Plugin/Comments/Config/Migration/1346931401_firstmigrationcomments.php
@@ -41,7 +41,7 @@ class FirstMigrationComments extends CakeMigration {
 					'indexes' => array(
 						'PRIMARY' => array('column' => 'id', 'unique' => 1)
 					),
-					'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+					'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 				),
 			),
 		),

--- a/Plugin/Comments/Config/Schema/schema.php
+++ b/Plugin/Comments/Config/Schema/schema.php
@@ -31,6 +31,6 @@ class CommentsSchema extends CakeSchema {
 		'indexes' => array(
 			'PRIMARY' => array('column' => 'id', 'unique' => 1)
 		),
-		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 	);
 }

--- a/Plugin/Comments/Test/Fixture/CommentFixture.php
+++ b/Plugin/Comments/Test/Fixture/CommentFixture.php
@@ -25,7 +25,7 @@ class CommentFixture extends CroogoTestFixture {
 		'updated' => array('type' => 'datetime', 'null' => false, 'default' => null),
 		'created' => array('type' => 'datetime', 'null' => false, 'default' => null),
 		'indexes' => array('PRIMARY' => array('column' => 'id', 'unique' => 1)),
-		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 	);
 
 	public $records = array(

--- a/Plugin/Contacts/Config/Migration/1346931401_firstmigrationcontacts.php
+++ b/Plugin/Contacts/Config/Migration/1346931401_firstmigrationcontacts.php
@@ -46,7 +46,7 @@ class FirstMigrationContacts extends CakeMigration {
 					'indexes' => array(
 						'PRIMARY' => array('column' => 'id', 'unique' => 1)
 					),
-					'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+					'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 				),
 				'messages' => array(
 					'id' => array('type' => 'integer', 'null' => false, 'default' => null, 'key' => 'primary'),
@@ -65,7 +65,7 @@ class FirstMigrationContacts extends CakeMigration {
 					'indexes' => array(
 						'PRIMARY' => array('column' => 'id', 'unique' => 1)
 					),
-					'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+					'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 				),
 			),
 		),

--- a/Plugin/Contacts/Config/Schema/schema.php
+++ b/Plugin/Contacts/Config/Schema/schema.php
@@ -35,7 +35,7 @@ class ContactsSchema extends CakeSchema {
 		'indexes' => array(
 			'PRIMARY' => array('column' => 'id', 'unique' => 1)
 		),
-		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 	);
 	
 	public $messages = array(
@@ -55,6 +55,6 @@ class ContactsSchema extends CakeSchema {
 		'indexes' => array(
 			'PRIMARY' => array('column' => 'id', 'unique' => 1)
 		),
-		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 	);
 }

--- a/Plugin/Contacts/Test/Fixture/ContactFixture.php
+++ b/Plugin/Contacts/Test/Fixture/ContactFixture.php
@@ -29,7 +29,7 @@ class ContactFixture extends CroogoTestFixture {
 		'updated' => array('type' => 'datetime', 'null' => false, 'default' => null),
 		'created' => array('type' => 'datetime', 'null' => false, 'default' => null),
 		'indexes' => array('PRIMARY' => array('column' => 'id', 'unique' => 1)),
-		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 	);
 
 	public $records = array(

--- a/Plugin/Contacts/Test/Fixture/MessageFixture.php
+++ b/Plugin/Contacts/Test/Fixture/MessageFixture.php
@@ -19,7 +19,7 @@ class MessageFixture extends CroogoTestFixture {
 		'updated' => array('type' => 'datetime', 'null' => false, 'default' => null),
 		'created' => array('type' => 'datetime', 'null' => false, 'default' => null),
 		'indexes' => array('PRIMARY' => array('column' => 'id', 'unique' => 1)),
-		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 	);
 
 	public $records = array(

--- a/Plugin/Menus/Config/Migration/1346931401_firstmigrationmenus.php
+++ b/Plugin/Menus/Config/Migration/1346931401_firstmigrationmenus.php
@@ -39,7 +39,7 @@ class FirstMigrationMenus extends CakeMigration {
 					'indexes' => array(
 						'PRIMARY' => array('column' => 'id', 'unique' => 1)
 					),
-					'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+					'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 				),
 				'menus' => array(
 					'id' => array('type' => 'integer', 'null' => false, 'default' => null, 'length' => 10, 'key' => 'primary'),
@@ -57,7 +57,7 @@ class FirstMigrationMenus extends CakeMigration {
 						'PRIMARY' => array('column' => 'id', 'unique' => 1),
 						'menu_alias' => array('column' => 'alias', 'unique' => 1)
 					),
-					'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+					'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 				),
 			),
 		),

--- a/Plugin/Menus/Config/Schema/schema.php
+++ b/Plugin/Menus/Config/Schema/schema.php
@@ -28,7 +28,7 @@ class MenusSchema extends CakeSchema {
 		'indexes' => array(
 			'PRIMARY' => array('column' => 'id', 'unique' => 1)
 		),
-		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 	);
 	public $menus = array(
 		'id' => array('type' => 'integer', 'null' => false, 'default' => null, 'length' => 10, 'key' => 'primary'),
@@ -46,6 +46,6 @@ class MenusSchema extends CakeSchema {
 			'PRIMARY' => array('column' => 'id', 'unique' => 1),
 			'menu_alias' => array('column' => 'alias', 'unique' => 1)
 		),
-		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 	);
 }

--- a/Plugin/Menus/Test/Fixture/LinkFixture.php
+++ b/Plugin/Menus/Test/Fixture/LinkFixture.php
@@ -22,7 +22,7 @@ class LinkFixture extends CroogoTestFixture {
 		'updated' => array('type' => 'datetime', 'null' => false, 'default' => null),
 		'created' => array('type' => 'datetime', 'null' => false, 'default' => null),
 		'indexes' => array('PRIMARY' => array('column' => 'id', 'unique' => 1)),
-		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 	);
 
 	public $records = array(

--- a/Plugin/Menus/Test/Fixture/MenuFixture.php
+++ b/Plugin/Menus/Test/Fixture/MenuFixture.php
@@ -19,7 +19,7 @@ class MenuFixture extends CroogoTestFixture {
 			'PRIMARY' => array('column' => 'id', 'unique' => 1),
 			'menu_alias' => array('column' => 'alias', 'unique' => 1),
 			),
-		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 	);
 
 	public $records = array(

--- a/Plugin/Meta/Config/Migration/1346931401_firstmigrationmeta.php
+++ b/Plugin/Meta/Config/Migration/1346931401_firstmigrationmeta.php
@@ -29,7 +29,7 @@ class FirstMigrationMeta extends CakeMigration {
 					'indexes' => array(
 						'PRIMARY' => array('column' => 'id', 'unique' => 1)
 					),
-					'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+					'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 				),
 			),
 		),

--- a/Plugin/Meta/Config/Schema/schema.php
+++ b/Plugin/Meta/Config/Schema/schema.php
@@ -18,6 +18,6 @@ class MetaSchema extends CakeSchema {
 		'indexes' => array(
 			'PRIMARY' => array('column' => 'id', 'unique' => 1)
 		),
-		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 	);
 }

--- a/Plugin/Meta/Test/Fixture/MetaFixture.php
+++ b/Plugin/Meta/Test/Fixture/MetaFixture.php
@@ -14,7 +14,7 @@ class MetaFixture extends CroogoTestFixture {
 		'value' => array('type' => 'text', 'null' => true, 'default' => null),
 		'weight' => array('type' => 'integer', 'null' => true, 'default' => null),
 		'indexes' => array('PRIMARY' => array('column' => 'id', 'unique' => 1)),
-		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 	);
 
 	public $records = array(

--- a/Plugin/Nodes/Config/Migration/1346931401_firstmigrationnodes.php
+++ b/Plugin/Nodes/Config/Migration/1346931401_firstmigrationnodes.php
@@ -44,14 +44,14 @@ class FirstMigrationNodes extends CakeMigration {
 					'indexes' => array(
 						'PRIMARY' => array('column' => 'id', 'unique' => 1)
 					),
-					'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+					'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 				),
 				'nodes_taxonomies' => array(
 					'id' => array('type' => 'integer', 'null' => false, 'default' => null, 'length' => 20, 'key' => 'primary'),
 					'node_id' => array('type' => 'integer', 'null' => false, 'default' => '0', 'length' => 20),
 					'taxonomy_id' => array('type' => 'integer', 'null' => false, 'default' => null, 'length' => 20),
 					'indexes' => array('PRIMARY' => array('column' => 'id', 'unique' => 1)),
-					'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+					'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 				),
 			),
 		),

--- a/Plugin/Nodes/Config/Schema/schema.php
+++ b/Plugin/Nodes/Config/Schema/schema.php
@@ -33,7 +33,7 @@ class NodesSchema extends CakeSchema {
 		'indexes' => array(
 			'PRIMARY' => array('column' => 'id', 'unique' => 1)
 		),
-		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 	);
 	
 	public $nodes_taxonomies = array(
@@ -41,6 +41,6 @@ class NodesSchema extends CakeSchema {
 		'node_id' => array('type' => 'integer', 'null' => false, 'default' => '0', 'length' => 20),
 		'taxonomy_id' => array('type' => 'integer', 'null' => false, 'default' => null, 'length' => 20),
 		'indexes' => array('PRIMARY' => array('column' => 'id', 'unique' => 1)),
-		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 	);
 }

--- a/Plugin/Nodes/Test/Fixture/NodeFixture.php
+++ b/Plugin/Nodes/Test/Fixture/NodeFixture.php
@@ -27,7 +27,7 @@ class NodeFixture extends CroogoTestFixture {
 		'updated' => array('type' => 'datetime', 'null' => false, 'default' => null),
 		'created' => array('type' => 'datetime', 'null' => false, 'default' => null),
 		'indexes' => array('PRIMARY' => array('column' => 'id', 'unique' => 1), 'slug' => array('column' => 'slug', 'unique' => 1)),
-		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 	);
 
 	public $records = array(

--- a/Plugin/Settings/Config/Migration/1346931401_firstmigrationsettings.php
+++ b/Plugin/Settings/Config/Migration/1346931401_firstmigrationsettings.php
@@ -31,7 +31,7 @@ class FirstMigrationSettings extends CakeMigration {
 					'indexes' => array(
 						'PRIMARY' => array('column' => 'id', 'unique' => 1)
 					),
-					'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+					'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 				),
 				'settings' => array(
 					'id' => array('type' => 'integer', 'null' => false, 'default' => null, 'length' => 20, 'key' => 'primary'),
@@ -47,7 +47,7 @@ class FirstMigrationSettings extends CakeMigration {
 						'PRIMARY' => array('column' => 'id', 'unique' => 1),
 						'key' => array('column' => 'key', 'unique' => 1)
 					),
-					'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+					'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 				),
 			),
 		),

--- a/Plugin/Settings/Config/Schema/schema.php
+++ b/Plugin/Settings/Config/Schema/schema.php
@@ -20,7 +20,7 @@ class SettingsSchema extends CakeSchema {
 		'indexes' => array(
 			'PRIMARY' => array('column' => 'id', 'unique' => 1)
 		),
-		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 	);
 	public $settings = array(
 		'id' => array('type' => 'integer', 'null' => false, 'default' => null, 'length' => 20, 'key' => 'primary'),
@@ -36,6 +36,6 @@ class SettingsSchema extends CakeSchema {
 			'PRIMARY' => array('column' => 'id', 'unique' => 1),
 			'key' => array('column' => 'key', 'unique' => 1)
 		),
-		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 	);
 }

--- a/Plugin/Settings/Test/Fixture/LanguageFixture.php
+++ b/Plugin/Settings/Test/Fixture/LanguageFixture.php
@@ -14,7 +14,7 @@ class LanguageFixture extends CroogoTestFixture {
 		'updated' => array('type' => 'datetime', 'null' => false, 'default' => null),
 		'created' => array('type' => 'datetime', 'null' => false, 'default' => null),
 		'indexes' => array('PRIMARY' => array('column' => 'id', 'unique' => 1)),
-		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 	);
 
 	public $records = array(

--- a/Plugin/Settings/Test/Fixture/SettingFixture.php
+++ b/Plugin/Settings/Test/Fixture/SettingFixture.php
@@ -15,7 +15,7 @@ class SettingFixture extends CroogoTestFixture {
 		'weight' => array('type' => 'integer', 'null' => true, 'default' => null),
 		'params' => array('type' => 'text', 'null' => false, 'default' => null),
 		'indexes' => array('PRIMARY' => array('column' => 'id', 'unique' => 1), 'key' => array('column' => 'key', 'unique' => 1)),
-		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 	);
 
 	public $records = array(

--- a/Plugin/Taxonomy/Config/Migration/1346931401_firstmigrationtaxonomy.php
+++ b/Plugin/Taxonomy/Config/Migration/1346931401_firstmigrationtaxonomy.php
@@ -29,7 +29,7 @@ class FirstMigrationTaxonomy extends CakeMigration {
 					'indexes' => array(
 						'PRIMARY' => array('column' => 'id', 'unique' => 1)
 					),
-					'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+					'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 				),
 				'terms' => array(
 					'id' => array('type' => 'integer', 'null' => false, 'default' => null, 'length' => 10, 'key' => 'primary'),
@@ -42,7 +42,7 @@ class FirstMigrationTaxonomy extends CakeMigration {
 						'PRIMARY' => array('column' => 'id', 'unique' => 1),
 						'slug' => array('column' => 'slug', 'unique' => 1)
 					),
-					'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+					'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 				),
 				'types' => array(
 					'id' => array('type' => 'integer', 'null' => false, 'default' => null, 'length' => 10, 'key' => 'primary'),
@@ -63,7 +63,7 @@ class FirstMigrationTaxonomy extends CakeMigration {
 						'PRIMARY' => array('column' => 'id', 'unique' => 1),
 						'type_alias' => array('column' => 'alias', 'unique' => 1)
 					),
-					'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+					'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 				),
 				'types_vocabularies' => array(
 					'id' => array('type' => 'integer', 'null' => false, 'default' => null, 'length' => 10, 'key' => 'primary'),
@@ -73,7 +73,7 @@ class FirstMigrationTaxonomy extends CakeMigration {
 					'indexes' => array(
 						'PRIMARY' => array('column' => 'id', 'unique' => 1)
 					),
-					'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+					'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 				),
 				'vocabularies' => array(
 					'id' => array('type' => 'integer', 'null' => false, 'default' => null, 'length' => 10, 'key' => 'primary'),
@@ -91,7 +91,7 @@ class FirstMigrationTaxonomy extends CakeMigration {
 						'PRIMARY' => array('column' => 'id', 'unique' => 1),
 						'vocabulary_alias' => array('column' => 'alias', 'unique' => 1)
 					),
-					'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+					'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 				),
 			),
 		),

--- a/Plugin/Taxonomy/Config/Schema/schema.php
+++ b/Plugin/Taxonomy/Config/Schema/schema.php
@@ -18,7 +18,7 @@ class TaxonomySchema extends CakeSchema {
 		'indexes' => array(
 			'PRIMARY' => array('column' => 'id', 'unique' => 1)
 		),
-		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 	);
 	public $terms = array(
 		'id' => array('type' => 'integer', 'null' => false, 'default' => null, 'length' => 10, 'key' => 'primary'),
@@ -31,7 +31,7 @@ class TaxonomySchema extends CakeSchema {
 			'PRIMARY' => array('column' => 'id', 'unique' => 1),
 			'slug' => array('column' => 'slug', 'unique' => 1)
 		),
-		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 	);
 	public $types = array(
 		'id' => array('type' => 'integer', 'null' => false, 'default' => null, 'length' => 10, 'key' => 'primary'),
@@ -52,7 +52,7 @@ class TaxonomySchema extends CakeSchema {
 			'PRIMARY' => array('column' => 'id', 'unique' => 1),
 			'type_alias' => array('column' => 'alias', 'unique' => 1)
 		),
-		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 	);
 	public $types_vocabularies = array(
 		'id' => array('type' => 'integer', 'null' => false, 'default' => null, 'length' => 10, 'key' => 'primary'),
@@ -62,7 +62,7 @@ class TaxonomySchema extends CakeSchema {
 		'indexes' => array(
 			'PRIMARY' => array('column' => 'id', 'unique' => 1)
 		),
-		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 	);
 	public $vocabularies = array(
 		'id' => array('type' => 'integer', 'null' => false, 'default' => null, 'length' => 10, 'key' => 'primary'),
@@ -80,6 +80,6 @@ class TaxonomySchema extends CakeSchema {
 			'PRIMARY' => array('column' => 'id', 'unique' => 1),
 			'vocabulary_alias' => array('column' => 'alias', 'unique' => 1)
 		),
-		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 	);
 }

--- a/Plugin/Taxonomy/Test/Fixture/NodesTaxonomyFixture.php
+++ b/Plugin/Taxonomy/Test/Fixture/NodesTaxonomyFixture.php
@@ -9,7 +9,7 @@ class NodesTaxonomyFixture extends CroogoTestFixture {
 		'node_id' => array('type' => 'integer', 'null' => false, 'default' => '0', 'length' => 20),
 		'taxonomy_id' => array('type' => 'integer', 'null' => false, 'default' => null, 'length' => 20),
 		'indexes' => array('PRIMARY' => array('column' => 'id', 'unique' => 1)),
-		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 	);
 
 	public $records = array(

--- a/Plugin/Taxonomy/Test/Fixture/TaxonomyFixture.php
+++ b/Plugin/Taxonomy/Test/Fixture/TaxonomyFixture.php
@@ -12,7 +12,7 @@ class TaxonomyFixture extends CroogoTestFixture {
 		'lft' => array('type' => 'integer', 'null' => true, 'default' => null),
 		'rght' => array('type' => 'integer', 'null' => true, 'default' => null),
 		'indexes' => array('PRIMARY' => array('column' => 'id', 'unique' => 1)),
-		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 	);
 
 	public $records = array(

--- a/Plugin/Taxonomy/Test/Fixture/TermFixture.php
+++ b/Plugin/Taxonomy/Test/Fixture/TermFixture.php
@@ -15,7 +15,7 @@ class TermFixture extends CroogoTestFixture {
 			'PRIMARY' => array('column' => 'id', 'unique' => 1),
 			'term_slug' => array('column' => 'slug', 'unique' => 1),
 			),
-		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 	);
 
 	public $records = array(

--- a/Plugin/Taxonomy/Test/Fixture/TypeFixture.php
+++ b/Plugin/Taxonomy/Test/Fixture/TypeFixture.php
@@ -23,7 +23,7 @@ class TypeFixture extends CroogoTestFixture {
 			'PRIMARY' => array('column' => 'id', 'unique' => 1),
 			'type_alias' => array('column' => 'alias', 'unique' => 1),
 			),
-		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 	);
 
 	public $records = array(

--- a/Plugin/Taxonomy/Test/Fixture/TypesVocabularyFixture.php
+++ b/Plugin/Taxonomy/Test/Fixture/TypesVocabularyFixture.php
@@ -10,7 +10,7 @@ class TypesVocabularyFixture extends CroogoTestFixture {
 		'vocabulary_id' => array('type' => 'integer', 'null' => false, 'default' => null, 'length' => 10),
 		'weight' => array('type' => 'integer', 'null' => true, 'default' => null),
 		'indexes' => array('PRIMARY' => array('column' => 'id', 'unique' => 1)),
-		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 	);
 
 	public $records = array(

--- a/Plugin/Taxonomy/Test/Fixture/VocabularyFixture.php
+++ b/Plugin/Taxonomy/Test/Fixture/VocabularyFixture.php
@@ -20,7 +20,7 @@ class VocabularyFixture extends CroogoTestFixture {
 			'PRIMARY' => array('column' => 'id', 'unique' => 1),
 			'vocabulary_alias' => array('column' => 'alias', 'unique' => 1),
 			),
-		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 	);
 
 	public $records = array(

--- a/Plugin/Translate/Config/Migration/1346931401_firstmigrationtranslate.php
+++ b/Plugin/Translate/Config/Migration/1346931401_firstmigrationtranslate.php
@@ -33,7 +33,7 @@ class FirstMigrationTranslate extends CakeMigration {
 						'row_id' => array('column' => 'foreign_key', 'unique' => 0),
 						'field' => array('column' => 'field', 'unique' => 0)
 					),
-					'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+					'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 				),
 			),
 		),

--- a/Plugin/Translate/Config/Schema/schema.php
+++ b/Plugin/Translate/Config/Schema/schema.php
@@ -22,6 +22,6 @@ class TranslateSchema extends CakeSchema {
 			'row_id' => array('column' => 'foreign_key', 'unique' => 0),
 			'field' => array('column' => 'field', 'unique' => 0)
 		),
-		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 	);
 }

--- a/Plugin/Users/Config/Migration/1346931401_firstmigrationusers.php
+++ b/Plugin/Users/Config/Migration/1346931401_firstmigrationusers.php
@@ -29,7 +29,7 @@ class FirstMigrationUsers extends CakeMigration {
 						'PRIMARY' => array('column' => 'id', 'unique' => 1),
 						'role_alias' => array('column' => 'alias', 'unique' => 1)
 					),
-					'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+					'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 				),
 				'roles_users' => array(
 					'id' => array('type' => 'integer', 'null' => false, 'default' => null, 'key' => 'primary'),
@@ -42,7 +42,7 @@ class FirstMigrationUsers extends CakeMigration {
 						'PRIMARY' => array('column' => 'id', 'unique' => 1),
 						'pk_role_users' => array('column' => array('user_id', 'role_id'), 'unique' => 1)
 					),
-					'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+					'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 				),
 				'users' => array(
 					'id' => array('type' => 'integer', 'null' => false, 'default' => null, 'length' => 20, 'key' => 'primary'),
@@ -62,7 +62,7 @@ class FirstMigrationUsers extends CakeMigration {
 					'indexes' => array(
 						'PRIMARY' => array('column' => 'id', 'unique' => 1)
 					),
-					'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+					'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 				),
 			),
 		),

--- a/Plugin/Users/Config/Schema/schema.php
+++ b/Plugin/Users/Config/Schema/schema.php
@@ -18,7 +18,7 @@ class UsersSchema extends CakeSchema {
 			'PRIMARY' => array('column' => 'id', 'unique' => 1),
 			'role_alias' => array('column' => 'alias', 'unique' => 1)
 		),
-		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 	);
 	public $roles_users = array(
 		'id' => array('type' => 'integer', 'null' => false, 'default' => null, 'key' => 'primary'),
@@ -31,7 +31,7 @@ class UsersSchema extends CakeSchema {
 			'PRIMARY' => array('column' => 'id', 'unique' => 1),
 			'pk_role_users' => array('column' => array('user_id', 'role_id'), 'unique' => 1)
 		),
-		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 	);
 	public $users = array(
 		'id' => array('type' => 'integer', 'null' => false, 'default' => null, 'length' => 20, 'key' => 'primary'),
@@ -51,6 +51,6 @@ class UsersSchema extends CakeSchema {
 		'indexes' => array(
 			'PRIMARY' => array('column' => 'id', 'unique' => 1)
 		),
-		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 	);
 }

--- a/Plugin/Users/Test/Fixture/RoleFixture.php
+++ b/Plugin/Users/Test/Fixture/RoleFixture.php
@@ -14,7 +14,7 @@ class RoleFixture extends CroogoTestFixture {
 			'PRIMARY' => array('column' => 'id', 'unique' => 1),
 			'role_alias' => array('column' => 'alias', 'unique' => 1),
 			),
-		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 	);
 
 	public $records = array(

--- a/Plugin/Users/Test/Fixture/UserFixture.php
+++ b/Plugin/Users/Test/Fixture/UserFixture.php
@@ -20,7 +20,7 @@ class UserFixture extends CroogoTestFixture {
 		'updated' => array('type' => 'datetime', 'null' => false, 'default' => null),
 		'created' => array('type' => 'datetime', 'null' => false, 'default' => null),
 		'indexes' => array('PRIMARY' => array('column' => 'id', 'unique' => 1)),
-		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 	);
 
 	public $records = array(

--- a/Test/Fixture/AcoFixture.php
+++ b/Test/Fixture/AcoFixture.php
@@ -13,7 +13,7 @@ class AcoFixture extends CroogoTestFixture {
 		'lft' => array('type' => 'integer', 'null' => true, 'default' => null, 'length' => 10),
 		'rght' => array('type' => 'integer', 'null' => true, 'default' => null, 'length' => 10),
 		'indexes' => array('PRIMARY' => array('column' => 'id', 'unique' => 1)),
-		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 	);
 
 	public $records = array(

--- a/Test/Fixture/AroFixture.php
+++ b/Test/Fixture/AroFixture.php
@@ -13,7 +13,7 @@ class AroFixture extends CroogoTestFixture {
 		'lft' => array('type' => 'integer', 'null' => true, 'default' => null, 'length' => 10),
 		'rght' => array('type' => 'integer', 'null' => true, 'default' => null, 'length' => 10),
 		'indexes' => array('PRIMARY' => array('column' => 'id', 'unique' => 1)),
-		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 	);
 
 	public $records = array(

--- a/Test/Fixture/ArosAcoFixture.php
+++ b/Test/Fixture/ArosAcoFixture.php
@@ -13,7 +13,7 @@ class ArosAcoFixture extends CroogoTestFixture {
 		'_update' => array('type' => 'string', 'null' => false, 'default' => '0', 'length' => 2),
 		'_delete' => array('type' => 'string', 'null' => false, 'default' => '0', 'length' => 2),
 		'indexes' => array('PRIMARY' => array('column' => 'id', 'unique' => 1)),
-		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'MyISAM')
+		'tableParameters' => array('charset' => 'utf8', 'collate' => 'utf8_unicode_ci', 'engine' => 'InnoDB')
 	);
 
 	public $records = array(


### PR DESCRIPTION
As per roadmap

To change the engine of MySQL we have updated first migrations files instead of creating new migrations because of a Migrations plugin limitation. See [here](https://github.com/CakeDC/migrations/issues/32#commit-ref-6352f4f)
