### PR TITLE
Tested and fixed the filter elements regex

### DIFF
--- a/Test/Case/View/Helper/LayoutHelperTest.php
+++ b/Test/Case/View/Helper/LayoutHelperTest.php
@@ -348,4 +348,20 @@ class LayoutHelperTest extends CroogoTestCase {
 		$Layout->filterElements($content);
 	}
 
+	public function testFilterElement_ParamsValueContainsEqual() {
+		$content = 'Lorem [element:map plugin="plugandrent" tricky-query="te=st" ]';
+		$View = $this->getMock('View');
+		$Layout = new LayoutHelper($View);
+
+		$View
+			->expects($this->once())
+			->method('element')
+			->with(
+				$this->equalTo('map'),
+				$this->equalTo(array('tricky-query' => 'te=st')),
+				$this->equalTo(array('plugin' => 'plugandrent'))
+			);
+		$Layout->filterElements($content);
+	}
+
 }

--- a/View/Helper/LayoutHelper.php
+++ b/View/Helper/LayoutHelper.php
@@ -328,7 +328,7 @@ class LayoutHelper extends AppHelper {
 		preg_match_all('/\[(element|e):([A-Za-z0-9_\-\/]*)(.*?)\]/i', $content, $tagMatches);
 		$validOptions = array('plugin', 'cache', 'callbacks');
 		for ($i = 0, $ii = count($tagMatches[1]); $i < $ii; $i++) {
-			$regex = '/(\S+)=[\'"]?((?:.(?![\'"]?\s+(?:\S+)=|[>\'"]))*.)[\'"]?/i';
+			$regex = '/([\w-]+)=[\'"]?((?:.(?![\'"]?\s+(?:\S+)=|[>\'"]))*.)[\'"]?/i';
 			preg_match_all($regex, $tagMatches[3][$i], $attributes);
 			$element = $tagMatches[2][$i];
 			$data = $options = array();


### PR DESCRIPTION
Added test coverage for the Layout::filterElements method, and fixed opened issues.
See http://croogo.lighthouseapp.com/projects/32818/tickets/133-regex-in-layout-filter-submethods-includes-left-quote-when-first-character-in-a-variable-value-is-a-digit
