### PR TITLE
Fixed the presetVars declaration for PrgComponent to match the search input

### DIFF
--- a/Plugin/Blocks/Controller/BlocksController.php
+++ b/Plugin/Blocks/Controller/BlocksController.php
@@ -42,7 +42,7 @@ class BlocksController extends BlocksAppController {
  */
 	public $presetVars = array(
 		'title' => array('type' => 'value'),
-		'region_id' => array('type' => 'lookup', 'formField' => 'region_input', 'modelField' => 'title', 'model' => 'Region')
+		'region_id' => array('type' => 'value')
 	);
 
 /**


### PR DESCRIPTION
... according to the Search plugin documentation lookup is for
the use case where there would be an autocomplete field with
a hidden "region_id" field.
It is useful to preset the "autocomplete" text value.
