### PR TITLE
The script execution time is nolonger appeneded to any pages

### DIFF
--- a/Controller/AppController.php
+++ b/Controller/AppController.php
@@ -149,20 +149,6 @@ class AppController extends Controller {
 	}
 
 /**
- * afterFilter callback
- * Disable debug mode on JSON pages to prevent the script execution time to be appended to the page
- *
- * @see http://croogo.lighthouseapp.com/projects/32818/tickets/216
- * @return void
- */
-	public function afterFilter() {
-		parent::afterFilter();
-		if (!empty($this->params['url']['ext']) && $this->params['url']['ext'] === 'json') {
-			Configure::write('debug', 0);
-		}
-	}
-
-/**
  * blackHoleCallback for SecurityComponent
  *
  * @return void


### PR DESCRIPTION
It was removed in
https://github.com/croogo/croogo/commit/d8b00f05c01700b5df6371c1b90c7f2f0bfa342c

about a year ago
