### PR TITLE
Settings: New Site.csrfExpires setting

### DIFF
--- a/Plugin/Croogo/Controller/CroogoAppController.php
+++ b/Plugin/Croogo/Controller/CroogoAppController.php
@@ -140,6 +140,11 @@ class CroogoAppController extends Controller {
 		$this->Security->blackHoleCallback = 'securityError';
 		$this->Security->requirePost('admin_delete');
 
+		$csrfExpires = Configure::read('Site.csrfExpires');
+		if (strtotime($csrfExpires) !== false) {
+			$this->Security->csrfExpires = $csrfExpires;
+		}
+
 		if (isset($this->request->params['admin'])) {
 			$this->layout = 'admin';
 		}

--- a/Plugin/Install/Config/Data/SettingData.php
+++ b/Plugin/Install/Config/Data/SettingData.php
@@ -301,6 +301,17 @@ class SettingData {
 			'weight' => '26',
 			'params' => 'multiple=checkboxoptions={"Nodes.Node": "Node", "Blocks.Block": "Block", "Menus.Menu": "Menu", "Menus.Link": "Link"}'
 		),
+		array(
+			'id' => '37',
+			'key' => 'Site.csrfExpires',
+			'value' => '+30 minutes',
+			'title' => 'Lifetime of CSRF Token',
+			'description' => 'The duration from when a CSRF token is created that it will expire on.',
+			'input_type' => 'radio',
+			'editable' => '1',
+			'weight' => '27',
+			'params' => 'options={"+10 minutes": "10 minutes", "+30 minutes": "30 minutes", "+1 hour": "1 hour", "+2 hours": "2 hours"}',
+		),
 	);
 
 }


### PR DESCRIPTION
End users can now configure their token expiry policy as needed.
Closes #344

Setting is rendered as such:

![CSRF](https://f.cloud.github.com/assets/39490/296693/b77e2d84-950d-11e2-8b10-2024c3ba722e.png)
