### PR TITLE
fixes set default language to english for all tests

### DIFF
--- a/Plugin/Croogo/Lib/TestSuite/CroogoControllerTestCase.php
+++ b/Plugin/Croogo/Lib/TestSuite/CroogoControllerTestCase.php
@@ -20,10 +20,12 @@ class CroogoControllerTestCase extends ControllerTestCase {
 
 	public static function setUpBeforeClass() {
 		self::_restoreSettings();
+		Configure::write('Config.language', 'eng');
 	}
 
 	public static function tearDownAfterClass() {
 		self::_restoreSettings();
+		Configure::write('Config.language', Configure::read('Site.locale'));
 	}
 
 	protected static function _restoreSettings() {

--- a/Plugin/Croogo/Lib/TestSuite/CroogoTestCase.php
+++ b/Plugin/Croogo/Lib/TestSuite/CroogoTestCase.php
@@ -21,10 +21,12 @@ class CroogoTestCase extends CakeTestCase {
 
 	public static function setUpBeforeClass() {
 		self::_restoreSettings();
+		Configure::write('Config.language', 'eng');
 	}
 
 	public static function tearDownAfterClass() {
 		self::_restoreSettings();
+		Configure::write('Config.language', Configure::read('Site.locale'));
 	}
 
 	protected static function _restoreSettings() {


### PR DESCRIPTION
To avoid failing tests when default language is different from english.
