### PR TITLE
Made Taxonomy terms translatable

### DIFF
--- a/Plugin/Translate/Config/bootstrap.php
+++ b/Plugin/Translate/Config/bootstrap.php
@@ -26,6 +26,13 @@ Configure::write('Translate.models', array(
 		),
 		'translateModel' => 'Menus.Link',
 	),
+	'Term' => array(
+		'fields' => array(
+			'title' => 'titleTranslation',
+			'description' => 'descriptionTranslation',
+		),
+		'translateModel' => 'Taxonomy.Term',
+	),
 ));
 
 /**


### PR DESCRIPTION
This make the Taxonomy terms translatable. Since both Translate and Terms are core plugins it makes sense to add this configuration here, also because it does not make much sense imo to have a blog in 2 languages with posts and pages translated but no categories.

Feel free to cancel the PR if you think it must be the responsibility of the application...
