### PR TITLE
Change title default to 'Home'

### DIFF
--- a/Plugin/Nodes/Controller/NodesController.php
+++ b/Plugin/Nodes/Controller/NodesController.php
@@ -517,7 +517,7 @@ class NodesController extends NodesAppController {
  * @access public
  */
 	public function promoted() {
-		$this->set('title_for_layout', __d('croogo', 'Nodes'));
+		$this->set('title_for_layout', __d('croogo', 'Home'));
 
 		$this->paginate['Node']['type'] = 'promoted';
 		$this->paginate['Node']['conditions'] = array(


### PR DESCRIPTION
Although we can do this in themes, or via plugins, this has annoyed me for ages. Let's use 'Home' instead.
