### PR TITLE
Fix transparency issue in png and gifs

### DIFF
--- a/Plugin/Croogo/View/Helper/ImageHelper.php
+++ b/Plugin/Croogo/View/Helper/ImageHelper.php
@@ -26,6 +26,7 @@ class ImageHelper extends Helper {
 	 */
 	public function resize($path, $width, $height, $aspect = true, $htmlAttributes = array(), $return = false) {
 		$types = array(1 => "gif", "jpeg", "png", "swf", "psd", "wbmp"); // used to determine image type
+		$transparency = array("gif", "png");	// image types with transparency
 		if (empty($htmlAttributes['alt'])) $htmlAttributes['alt'] = 'thumb';  // Ponemos alt default
 
 		$uploadsDir = 'uploads';
@@ -64,9 +65,22 @@ class ImageHelper extends Helper {
 		if ($resize) {
 			$image = call_user_func('imagecreatefrom'.$types[$size[2]], $url);
 			if (function_exists("imagecreatetruecolor") && ($temp = imagecreatetruecolor ($width, $height))) {
+				if( in_array($types[$size[2]],$transparency) ){
+				  imagealphablending($temp, false);
+				  imagesavealpha($temp,true);
+				  $transparent = imagecolorallocatealpha($temp, 255, 255, 255, 127);
+				  imagefilledrectangle($temp, 0, 0, $width, $height, $transparent);
+				 }
 				imagecopyresampled ($temp, $image, 0, 0, 0, 0, $width, $height, $size[0], $size[1]);
 			} else {
 				$temp = imagecreate ($width, $height);
+				if( in_array($types[$size[2]],$transparency) ){
+				  imagealphablending($temp, false);
+				  imagesavealpha($temp,true);
+				  $transparent = imagecolorallocatealpha($temp, 255, 255, 255, 127);
+				  imagefilledrectangle($temp, 0, 0, $width, $height, $transparent);
+				 }
+
 				imagecopyresized ($temp, $image, 0, 0, 0, 0, $width, $height, $size[0], $size[1]);
 			}
 			call_user_func("image".$types[$size[2]], $temp, $cachefile);


### PR DESCRIPTION
http://www.akemapa.com/2008/07/10/php-gd-resize-transparent-image-png-gif/

https://groups.google.com/forum/?fromgroups#!topic/croogo/F00CZBvmf7g

http://croogo.lighthouseapp.com/projects/32818/tickets/396-resized-png-attachments-are-plain-black
