### PR TITLE
Set the standard JSON content type for a wider compatibility

### DIFF
--- a/Plugin/Croogo/Controller/CroogoAppController.php
+++ b/Plugin/Croogo/Controller/CroogoAppController.php
@@ -137,7 +137,7 @@ class CroogoAppController extends Controller {
 			throw new MissingComponentException(array('class' => $aclFilterComponent));
 		}
 		$this->{$aclFilterComponent}->auth();
-		$this->RequestHandler->setContent('json', 'text/x-json');
+		$this->RequestHandler->setContent('json', array('text/x-json', 'application/json'));
 		$this->Security->blackHoleCallback = 'securityError';
 		$this->Security->requirePost('admin_delete');
 


### PR DESCRIPTION
Since the "application/json" type is the default one used in CakePHP core and accepted in a RFC4627

see http://stackoverflow.com/questions/477816/what-is-the-correct-json-content-type for further information
