### PR TITLE
Adding AppModel reference to UsersAppModel.

### DIFF
--- a/Plugin/Users/Model/UsersAppModel.php
+++ b/Plugin/Users/Model/UsersAppModel.php
@@ -1,5 +1,7 @@
 <?php
 
+App::uses('AppModel', 'Model');
+
 /**
  * @package Croogo.Users.Model
  */


### PR DESCRIPTION
Without this line, testsuite will fail when launch via CLI.
