### PR TITLE
Fix infinite loop in CakeErrorController due to NotFoundException 

### DIFF
--- a/Plugin/Croogo/Controller/CroogoAppController.php
+++ b/Plugin/Croogo/Controller/CroogoAppController.php
@@ -217,7 +217,7 @@ class CroogoAppController extends Controller {
  * @see Controller::render()
  */
 	public function render($view = null, $layout = null) {
-		if (strpos($view, '/') !== false) {
+		if (strpos($view, '/') !== false || $this instanceof CakeErrorController) {
 			return parent::render($view, $layout);
 		}
 		$viewPaths = App::path('View', $this->plugin);


### PR DESCRIPTION
Resolution proposed by rchavik and tested by myself to problem I reported in IRC where NotFoundException thrown in Comments::CommentModel::isValidLevel() was resulting in a PHP loop which failed when memory_limit or max_nesting were exceeded.
