### PR TITLE
Fix password generation when adding Admin from Install CLI.

### DIFF
--- a/Install/Console/Command/InstallShell.php
+++ b/Install/Console/Command/InstallShell.php
@@ -107,7 +107,7 @@ class InstallShell extends AppShell {
 		} while (empty($password) || !$passwordsMatched);
 
 		$user['User']['username'] = $username;
-		$user['User']['password'] = AuthComponent::password($password);
+		$user['User']['password'] = $password;
 
 		$Install->addAdminUser($user);
 		$InstallManager->createSettingsFile();


### PR DESCRIPTION
When adding an admin from install Cli, you cannot logged into backend.

To reproduce, install a fresh croogo app, run `Console/cake Install.install`, setup database, add admin, then try to login into backend. 

It will fail.

Since `Users.User::beforeSave()` already encode password, no need to encode it.
