### PR TITLE
Update navbar.less

### DIFF
--- a/Plugin/Croogo/webroot/less/navbar.less
+++ b/Plugin/Croogo/webroot/less/navbar.less
@@ -1,4 +1,3 @@
-
 // Sidebar
 .sidebar {
 	font-family: @sansFontFamily;
@@ -44,6 +43,11 @@
 
 		span {
 			margin: 0 8px;
+			vertical-align: middle;
+			display: -moz-inline-stack;
+			display: inline-block;
+			zoom: 1;
+			*display: inline;
 		}
 
 	}


### PR DESCRIPTION
Added to .sidebar .sidebar-item span (lines 46-50). A cross browser method (as per the original post by the [Mozilla Team](http://blog.mozilla.org/webdev/2009/02/20/cross-browser-inline-block/)) of displaying the span inline-block.

This means that when a menu item double lines (for instance add a `<br/>` tag to a title in your CroogoNav::add() declaration) the text lines up neatly.

This pull request is in response to @rchavik requesting the css to go into the navbar.less file rather than the croogo-boostrap.css file.
