### PR TITLE
Fixes issue #146.

### DIFF
--- a/Plugin/Comments/Controller/CommentsController.php
+++ b/Plugin/Comments/Controller/CommentsController.php
@@ -166,10 +166,10 @@ class CommentsController extends CommentsAppController {
 			$this->Comment->deleteAll(array('Comment.id' => $ids), true, true)) {
 			$this->Session->setFlash(__d('croogo', 'Comments deleted'), 'default', array('class' => 'success'));
 		} elseif ($action == 'publish' &&
-			$this->Comment->updateAll(array('Comment.status' => true), array('Comment.id' => $ids))) {
+			$this->Comment->changeStatus($ids, true)) {
 			$this->Session->setFlash(__d('croogo', 'Comments published'), 'default', array('class' => 'success'));
 		} elseif ($action == 'unpublish' &&
-			$this->Comment->updateAll(array('Comment.status' => false), array('Comment.id' => $ids))) {
+			$this->Comment->changeStatus($ids, false)) {
 			$this->Session->setFlash(__d('croogo', 'Comments unpublished'), 'default', array('class' => 'success'));
 		} else {
 			$this->Session->setFlash(__d('croogo', 'An error occurred.'), 'default', array('class' => 'error'));

--- a/Plugin/Comments/Model/Comment.php
+++ b/Plugin/Comments/Model/Comment.php
@@ -182,4 +182,15 @@ class Comment extends AppModel {
 		return Configure::read('Comment.level') > $level;
 	}
 
+	public function changeStatus($ids, $status) {
+		$dataArray = array();
+		foreach ($ids as $id) {
+			$dataArray[] = array(
+				$this->primaryKey => $id,
+				'status' => $status
+			);
+		}
+		return $this->saveMany($dataArray, array('validate' => false));
+	}
+
 }

--- a/Plugin/Comments/Test/Case/Controller/CommentsControllerTest.php
+++ b/Plugin/Comments/Test/Case/Controller/CommentsControllerTest.php
@@ -153,7 +153,10 @@ class CommentsControllerTest extends CroogoControllerTestCase {
 			'id' => 1,
 			'status' => 0,
 		));
+		$relevantNode = $this->CommentsController->Comment->Node->findById(1);
 		$this->assertTrue($comment);
+		//Ensure that the counterCache field has been updated for the rest of the test
+		$this->assertEqual($relevantNode['Node']['comment_count'], 0);
 
 		$this->expectFlashAndRedirect('Comments published');
 
@@ -179,6 +182,9 @@ class CommentsControllerTest extends CroogoControllerTestCase {
 		$this->assertEqual($list, array(
 			'1' => 'Mr Croogo',
 		));
+
+		$relevantNode = $this->CommentsController->Comment->Node->findById(1);
+		$this->assertEqual($relevantNode['Node']['comment_count'], 1);
 	}
 
 /**
@@ -207,6 +213,9 @@ class CommentsControllerTest extends CroogoControllerTestCase {
 			'order' => 'Comment.lft ASC',
 		));
 		$this->assertEqual($list, array());
+
+		$relevantNode = $this->CommentsController->Comment->Node->findById(1);
+		$this->assertEqual($relevantNode['Node']['comment_count'], 0);
 	}
 
 /**


### PR DESCRIPTION
Fix is done by removing the updateAll() call when publishing, or unpublishing multiple comments. The problem was that updateAll() does not run any callbacks, so the built in counterCache does not get updated. Also added test cases.
