### PR TITLE
Update admin_login.ctp

### DIFF
--- a/Plugin/Users/View/Users/admin_login.ctp
+++ b/Plugin/Users/View/Users/admin_login.ctp
@@ -12,7 +12,7 @@
 			'class' => 'span11',
 		));
 		echo $this->Form->input('password', array(
-			'placeholder' => 'Password',
+			'placeholder' => __d('croogo', 'Password'),
 			'before' => '<span class="add-on"><i class="icon-key"></i></span>',
 			'div' => 'input-prepend password',
 			'class' => 'span11',


### PR DESCRIPTION
the placeholder Password in admin_login not translated when changing language

..app\Plugin\Users\View\Users\admin_login.ctp

line 15
Replace 
'placeholder' => 'Password',

by
'placeholder' => __d('croogo', 'Password'),
