### PR TITLE
Update croogo_bootstrap.php

### DIFF
--- a/Croogo/Config/croogo_bootstrap.php
+++ b/Croogo/Config/croogo_bootstrap.php
@@ -80,11 +80,17 @@ foreach ($plugins as $plugin) {
 	$pluginName = Inflector::camelize($plugin);
 	$pluginPath = APP . 'Plugin' . DS . $pluginName;
 	if (!file_exists($pluginPath)) {
-		$pluginPath = APP . 'Vendor' . DS . 'croogo' . DS . 'croogo' . DS . $pluginName;
-		if (!file_exists($pluginPath)) {
+	        $pluginFound = false;
+	        foreach(App::path('Plugin') as $path){
+			if(is_dir($path.$pluginName)){
+				$pluginFound=true;
+				break;
+			}
+	        }
+	        if(!$pluginFound){
 			CakeLog::error('Plugin not found during bootstrap: ' . $pluginName);
 			continue;
-		}
+	        }
 	}
 	$option = array(
 		$pluginName => array(


### PR DESCRIPTION
Currently the plugins can't be loaded from other vendors.
If you define another App::build path it is ignored.
This change will allow the plugins to be loaded from other vendors by looping through the defined plugin paths.
