### PR TITLE
Fix missing default session settings prior to the installation process

### DIFF
--- a/Config/core.php
+++ b/Config/core.php
@@ -18,4 +18,11 @@ if (file_exists(APP . 'Config' . DS . 'croogo.php')) {
 		'renderer' => 'ExceptionRenderer',
 		'log' => true
 	));
+
+	Configure::write('Session', array(
+		'defaults' => 'php',
+		'ini' => array(
+			'session.cookie_httponly' => 1
+		)
+	));
 }


### PR DESCRIPTION
I've added a session setting in the core.php file because the ini_set function on php version 5.5 will return false if the newvalue param is NULL
