### PR TITLE
Made terms description nullable in fixtures

### DIFF
--- a/Plugin/Taxonomy/Test/Fixture/TermFixture.php
+++ b/Plugin/Taxonomy/Test/Fixture/TermFixture.php
@@ -8,7 +8,7 @@ class TermFixture extends CroogoTestFixture {
 		'id' => array('type' => 'integer', 'null' => false, 'default' => null, 'length' => 10, 'key' => 'primary'),
 		'title' => array('type' => 'string', 'null' => false, 'default' => null),
 		'slug' => array('type' => 'string', 'null' => false, 'default' => null, 'key' => 'unique'),
-		'description' => array('type' => 'text', 'null' => false, 'default' => null),
+		'description' => array('type' => 'text', 'null' => true, 'default' => null),
 		'updated' => array('type' => 'datetime', 'null' => false, 'default' => null),
 		'created' => array('type' => 'datetime', 'null' => false, 'default' => null),
 		'indexes' => array(


### PR DESCRIPTION
As they are nullable as describe in migrations https://github.com/croogo/croogo/blob/master/Plugin/Taxonomy/Config/Migration/1346931401_firstmigrationtaxonomy.php
