### PR TITLE
Fix notices displayed when failing to add a new node.

### DIFF
--- a/Nodes/Controller/NodesController.php
+++ b/Nodes/Controller/NodesController.php
@@ -184,9 +184,8 @@ class NodesController extends NodesAppController {
 					'Node.type' => $this->Node->type,
 				),
 			));
-
-			$this->_setCommonVariables($type);
 		}
+		$this->_setCommonVariables($type);
 	}
 
 /**


### PR DESCRIPTION
Actual case:
When failing to add new node a lot of notices show up (undefined vars and indexes).

This commit prevents those notices to be displayed by moving _setCommonVariables() outside main if statement in admin_add action.
