### PR TITLE
The form input should use the configured value

### DIFF
--- a/Plugin/Taxonomy/View/Elements/admin/terms_tab.ctp
+++ b/Plugin/Taxonomy/View/Elements/admin/terms_tab.ctp
@@ -5,7 +5,7 @@ if (count($taxonomy) > 0):
 		echo $this->Form->input('TaxonomyData.' . $vocabularyId, array(
 			'label' => $vocabularies[$vocabularyId]['title'],
 			'type' => 'select',
-			'multiple' => true,
+			'multiple' => $vocabularies[$vocabularyId]['multiple'],
 			'options' => $taxonomyTree,
 			'value' => $taxonomyIds,
 			'class' => false,


### PR DESCRIPTION
The form input should use the configured value to tell whether it's multiple or not, instead of hard coding it to true.
