### PR TITLE
Fix - New Language added has no weight

### DIFF
--- a/Plugin/Croogo/Model/Behavior/OrderedBehavior.php
+++ b/Plugin/Croogo/Model/Behavior/OrderedBehavior.php
@@ -164,7 +164,7 @@ class OrderedBehavior extends ModelBehavior {
 	public function beforeSave(Model $Model, $options = array()) {
 		// Check if weight id is set. If not add to end, if set update all
 		// rows from ID and up
-		if (!isset($Model->data[$Model->alias][$Model->primaryKey])) {
+		if (empty($Model->data[$Model->alias][$Model->primaryKey])) {
 			// get highest current row
 			$highest = $this->_highest($Model);
 			// set new weight to model as last by using current highest one + 1


### PR DESCRIPTION
I'm sorry I didn't take the time to add a test case to underline my fix.

Prior this fix:
But when you added a new record, the new record has no weight set.

The purpose of my fix is to set a weight to a new record. 

This case happened when primaryKey field is set but empty.
