### PR TITLE
Added useful alt property for images

### DIFF
--- a/Plugin/FileManager/View/Attachments/admin_index.ctp
+++ b/Plugin/FileManager/View/Attachments/admin_index.ctp
@@ -40,11 +40,11 @@ $this->Html
 		$mimeType = explode('/', $attachment['Attachment']['mime_type']);
 		$mimeType = $mimeType['0'];
 		if ($mimeType == 'image') {
-			$imgUrl = $this->Image->resize('/uploads/' . $attachment['Attachment']['slug'], 100, 200, true, array('class' => 'img-polaroid'));
+			$imgUrl = $this->Image->resize('/uploads/' . $attachment['Attachment']['slug'], 100, 200, true, array('class' => 'img-polaroid', 'alt' => $attachment['Attachment']['title']));
 			$thumbnail = $this->Html->link($imgUrl, $attachment['Attachment']['path'],
 			array('escape' => false, 'class' => 'thickbox', 'title' => $attachment['Attachment']['title']));
 		} else {
-			$thumbnail = $this->Html->image('/croogo/img/icons/page_white.png') . ' ' . $attachment['Attachment']['mime_type'] . ' (' . $this->Filemanager->filename2ext($attachment['Attachment']['slug']) . ')';
+			$thumbnail = $this->Html->image('/croogo/img/icons/page_white.png', array('alt' => $attachment['Attachment']['mime_type'])) . ' ' . $attachment['Attachment']['mime_type'] . ' (' . $this->Filemanager->filename2ext($attachment['Attachment']['slug']) . ')';
 		}
 
 		$actions = $this->Html->div('item-actions', implode(' ', $actions));


### PR DESCRIPTION
page_white image didnt have an alt, and thumbnails had generic default alts (thumb); this sets alt for page_white image as the mime type and the title of the attachment for thumbnails.
