### PR TITLE
Allow overriding the default variables for ImageHelper::resize()

### DIFF
--- a/Croogo/View/Helper/ImageHelper.php
+++ b/Croogo/View/Helper/ImageHelper.php
@@ -31,15 +31,18 @@ class ImageHelper extends Helper {
 		$options = Hash::merge(array(
 			'aspect' => true,
 			'uploadsDir' => 'uploads',
+			'cacheDir' => $this->cacheDir,
+			'resizedInd' => '.resized-',
 		), $options);
 		$aspect = $options['aspect'];
 		$uploadsDir = $options['uploadsDir'];
+		$cacheDir = $options['cacheDir'];
+		$resizedInd = $options['resizedInd'];
 		$types = array(1 => "gif", "jpeg", "png", "swf", "psd", "wbmp"); // used to determine image type
 		$transparency = array("gif", "png");	// image types with transparency
 		if (empty($htmlAttributes['alt'])) $htmlAttributes['alt'] = 'thumb';  // Ponemos alt default
 
-		$fullpath = ROOT.DS.APP_DIR.DS.WEBROOT_DIR.DS.$uploadsDir.DS;
-		$url = ROOT.DS.APP_DIR.DS.WEBROOT_DIR.DS.$path;
+		$url = WWW_ROOT . DS . $path;
 
 		if (!file_exists($url)) {
 			return; // image doesn't exist
@@ -54,8 +57,25 @@ class ImageHelper extends Helper {
 				$height = ceil($width / ($size[0]/$size[1]));
 		}
 
-		$relfile = $this->webroot.$uploadsDir.'/'.$this->cacheDir.'/'.$width.'x'.$height.'_'.basename($path); // relative file
-		$cachefile = $fullpath.$this->cacheDir.DS.$width.'x'.$height.'_'.basename($path);  // location on server
+		$dimension = $resizedInd . $width . 'x' . $height;
+		$parts = pathinfo(WWW_ROOT . $path);
+		if ($resizedInd === 'resized') {
+			// legacy format
+			$resized = $width . 'x' . $height . '_' . $parts['filename'] . '.' . $parts['extension'];
+		} elseif (strpos($path, $resizedInd) === false) {
+			$resized = $parts['filename'] . $dimension . '.' . $parts['extension'];
+		} else {
+			$resized = $parts['filename'] . '.' . $parts['extension'];
+		}
+		$relfile = '/';
+		if ($uploadsDir) {
+			$relfile .= ltrim($uploadsDir, '/') . '/';
+		}
+		if ($cacheDir) {
+			$relfile .= ltrim($cacheDir, '/') . '/';
+		}
+		$relfile .= $resized;
+		$cachefile = WWW_ROOT . ltrim($relfile, '/');
 
 		if (file_exists($cachefile)) {
 			$csize = getimagesize($cachefile);


### PR DESCRIPTION
This is needed if plugins want to use a different path, etc.

Will introduce BC break for E_STRICT users, but should work normally otherwise.
