### PR TITLE
Specify Plugin for behavior

### DIFF
--- a/Plugin/Settings/Controller/SettingsController.php
+++ b/Plugin/Settings/Controller/SettingsController.php
@@ -155,7 +155,7 @@ class SettingsController extends SettingsAppController {
 	public function admin_prefix($prefix = null) {
 		$this->set('title_for_layout', __d('croogo', 'Settings: %s', $prefix));
 
-		$this->Setting->Behaviors->attach('Params');
+		$this->Setting->Behaviors->attach('Croogo.Params');
 		if (!empty($this->request->data) && $this->Setting->saveAll($this->request->data['Setting'])) {
 			$this->Session->setFlash(__d('croogo', "Settings updated successfully"), 'default', array('class' => 'success'));
 			$this->redirect(array('action' => 'prefix', $prefix));


### PR DESCRIPTION
When removing plugin bootstraps, this caused a Behavior not found error.
