### PR TITLE
Fixes error of image not showing when croogo is installed in folder

### DIFF
--- a/Croogo/View/Helper/ImageHelper.php
+++ b/Croogo/View/Helper/ImageHelper.php
@@ -121,6 +121,6 @@ class ImageHelper extends Helper {
 			//copy($url, $cachefile);
 		}
 
-		return $this->output(sprintf($this->Html->_tags['image'], $relfile, $this->Html->_parseAttributes($htmlAttributes, null, '', ' ')), $return);
+		return $this->output(sprintf($this->Html->_tags['image'], $this->webroot($relfile), $this->Html->_parseAttributes($htmlAttributes, null, '', ' ')), $return);
 	}
 }


### PR DESCRIPTION
The helper returns an images that makes reference to the root of the domain instead of croogo's webroot.
