### PR TITLE
Fixes #435: table cells overflowing when containing large urls

### DIFF
--- a/Plugin/Croogo/webroot/less/tables.less
+++ b/Plugin/Croogo/webroot/less/tables.less
@@ -10,6 +10,9 @@
 			.sortDirections();
 		}
 	}
+	td {
+		word-break: break-all;
+	}
 }
 
 table {


### PR DESCRIPTION
See http://croogo.lighthouseapp.com/projects/32818-croogo/tickets/435-attachements-with-long-title-actions-icons-outside-page
