### PR TITLE
Update admin_index.ctp

### DIFF
--- a/Plugin/Taxonomy/View/Terms/admin_index.ctp
+++ b/Plugin/Taxonomy/View/Terms/admin_index.ctp
@@ -24,14 +24,6 @@ $this->Html
 			$this->Paginator->options['url'][] = $nn . ':' . $nv;
 		}
 	}
-
-	echo $this->Form->create('Term', array(
-		'url' => array(
-			'controller' => 'terms',
-			'action' => 'process',
-			'vocabulary' => $vocabulary['Vocabulary']['id'],
-		),
-	));
 ?>
 <table class="table table-striped">
 <?php


### PR DESCRIPTION
Fix to ticket: http://croogo.lighthouseapp.com/projects/32818-croogo/tickets/482-taxonomyterms-cant-delete-first-term-in-index#ticket-482-4

Unclosed and unnecessary form->create() call was causing the first delete link in index not to work.
