### PR TITLE
Avoid "Unknown column `Block`.`chooser`" SQL errors

### DIFF
--- a/Plugin/Blocks/Controller/BlocksController.php
+++ b/Plugin/Blocks/Controller/BlocksController.php
@@ -102,7 +102,8 @@ class BlocksController extends BlocksAppController {
 		$this->Block->recursive = 0;
 		$this->paginate['Block']['order'] = array('Block.weight' => 'ASC');
 
-		$this->set('blocks', $this->paginate($this->Block->parseCriteria($this->request->query)));
+		$criteria = $this->Block->parseCriteria($this->Prg->parsedParams());
+		$this->set('blocks', $this->paginate($criteria));
 		$this->set('regions', $this->Block->Region->find('list'));
 		$this->set('searchFields', $searchFields);
 		if (isset($this->request->query['chooser'])) {

--- a/Plugin/Blocks/Controller/RegionsController.php
+++ b/Plugin/Blocks/Controller/RegionsController.php
@@ -69,7 +69,8 @@ class RegionsController extends BlocksAppController {
 
 		$this->Region->recursive = 0;
 		$this->paginate['Region']['order'] = 'Region.title ASC';
-		$this->set('regions', $this->paginate($this->Region->parseCriteria($this->request->query)));
+		$criteria = $this->Region->parseCriteria($this->Prg->parsedParams());
+		$this->set('regions', $this->paginate($criteria));
 		$this->set('displayFields', $this->Region->displayFields());
 		$this->set('searchFields', $searchFields);
 	}

--- a/Plugin/Blocks/Model/Block.php
+++ b/Plugin/Blocks/Model/Block.php
@@ -73,7 +73,6 @@ class Block extends BlocksAppModel {
  * @access public
  */
 	public $filterArgs = array(
-		'chooser' => array('type' => null),
 		'title' => array('type' => 'like', 'field' => array('Block.title', 'Block.alias')),
 		'region_id' => array('type' => 'value'),
 	);

--- a/Plugin/Blocks/Model/Region.php
+++ b/Plugin/Blocks/Model/Region.php
@@ -67,7 +67,6 @@ class Region extends BlocksAppModel {
  * @access public
  */
 	public $filterArgs = array(
-		'chooser' => array('type' => null),
 		'title' => array('type' => 'like', 'field' => array('Region.title'))
 	);
 

--- a/Plugin/Comments/Controller/CommentsController.php
+++ b/Plugin/Comments/Controller/CommentsController.php
@@ -86,7 +86,7 @@ class CommentsController extends CommentsAppController {
 			'Comment.comment_type' => 'comment',
 		);
 
-		$criteria = $this->Comment->parseCriteria($this->request->query);
+		$criteria = $this->Comment->parseCriteria($this->Prg->parsedParams());
 		if (array_key_exists('Comment.status', $criteria)) {
 			$criteria = array_merge($this->paginate['Comment']['conditions'], $criteria);
 		}

--- a/Plugin/Contacts/Controller/MessagesController.php
+++ b/Plugin/Contacts/Controller/MessagesController.php
@@ -64,7 +64,7 @@ class MessagesController extends ContactsAppController {
 		$this->Prg->commonProcess();
 
 		$this->Message->recursive = 0;
-		$criteria = $this->Message->parseCriteria($this->request->query);
+		$criteria = $this->Message->parseCriteria($this->Prg->parsedParams());
 		$contacts = $this->Message->Contact->find('list');
 		$messages = $this->paginate($criteria);
 		$searchFields = array('contact_id', 'status' => array(

--- a/Plugin/Nodes/Controller/NodesController.php
+++ b/Plugin/Nodes/Controller/NodesController.php
@@ -116,7 +116,8 @@ class NodesController extends NodesAppController {
 		$typeAliases = Hash::extract($types, '{n}.Type.alias');
 		$this->paginate['Node']['conditions']['Node.type'] = $typeAliases;
 
-		$nodes = $this->paginate($this->Node->parseCriteria($this->request->query));
+		$criteria = $this->Node->parseCriteria($this->Prg->parsedParams());
+		$nodes = $this->paginate($criteria);
 		$nodeTypes = $this->Node->Taxonomy->Vocabulary->Type->find('list', array(
 			'fields' => array('Type.alias', 'Type.title')
 			));

--- a/Plugin/Users/Controller/UsersController.php
+++ b/Plugin/Users/Controller/UsersController.php
@@ -110,7 +110,8 @@ class UsersController extends UsersAppController {
 		$searchFields = array('role_id', 'name');
 
 		$this->User->recursive = 0;
-		$this->paginate['conditions'] = $this->User->parseCriteria($this->request->query);
+		$criteria = $this->User->parseCriteria($this->Prg->parsedParams());
+		$this->paginate['conditions'] = $criteria;
 
 		$this->set('users', $this->paginate());
 		$this->set('roles', $this->User->Role->find('list'));

--- a/Plugin/Users/Model/User.php
+++ b/Plugin/Users/Model/User.php
@@ -124,7 +124,6 @@ class User extends UsersAppModel {
  * @access public
  */
 	public $filterArgs = array(
-		'chooser' => array('type' => null),
 		'name' => array('type' => 'like', 'field' => array('User.name', 'User.username')),
 		'role_id' => array('type' => 'value'),
 	);


### PR DESCRIPTION
The `chooser` query variable causes the Search plugin to include it
in the generated SQL.  Avoid this by filtering these internal query variables
out prior to calling Model::find() or Controller::paginate().
