### PR TITLE
Fixed buttons not displayed when in a custom block

### DIFF
--- a/Croogo/View/Common/admin_edit.ctp
+++ b/Croogo/View/Common/admin_edit.ctp
@@ -77,7 +77,7 @@ $what = isset($this->request->data[$modelClass]['id']) ? __d('croogo', 'Edit') :
 		<div class="span4">
 		<?php
 			if ($buttonsBlock = $this->fetch('buttons')):
-				$publishing = $buttonsBlock;
+				echo $buttonsBlock;
 			else :
 				echo $this->Html->beginBox('Publishing') .
 					$this->Form->button(__d('croogo', 'Save'), array('button' => 'primary')) .


### PR DESCRIPTION
I have not find the reason why it has been written this way, the `$publishing` variable seems unused. It might be a typo here since the first version.

Can anyone double check please?
