### PR TITLE
allow link params field to set escape=false

### DIFF
--- a/Plugin/Menus/View/Helper/MenusHelper.php
+++ b/Plugin/Menus/View/Helper/MenusHelper.php
@@ -148,10 +148,14 @@ class MenusHelper extends AppHelper {
 				'class' => $link['Link']['class'],
 			);
 
+			$linkAttr = array_merge($linkAttr,$link['Params']);
 			foreach ($linkAttr as $attrKey => $attrValue) {
 				if ($attrValue == null) {
 					unset($linkAttr[$attrKey]);
 				}
+                		else if ($attrValue === 'false'){
+                    			$linkAttr[$attrKey] = false;
+                		}
 			}
 
 			// if link is in the format: controller:contacts/action:view


### PR DESCRIPTION
i'm no cake/php dev, so please take a look and beautify this commit...
as far as i can see $link['Params'] aren't used at all?, so i merged them into the linkAttr array
