### PR TITLE
Teach MetaHelper::meta() to accept array from 'Meta' configure key

### DIFF
--- a/Meta/View/Helper/MetaHelper.php
+++ b/Meta/View/Helper/MetaHelper.php
@@ -58,7 +58,16 @@ class MetaHelper extends AppHelper {
 
 		$output = '';
 		foreach ($metaForLayout as $name => $content) {
-			$output .= '<meta name="' . $name . '" content="' . $content . '" />';
+			if (is_array($content) && isset($content['content'])) {
+				$attr = key($content);
+				$attrValue = $content[$attr];
+				$value = $content['content'];
+			} else {
+				$attr = 'name';
+				$attrValue = $name;
+				$value = $content;
+			}
+			$output .= '<meta ' . $attr . '="' . $attrValue . '" content="' . $value . '" />';
 		}
 
 		return $output;


### PR DESCRIPTION
Allows:

``` php
    Configure::write('Meta', array(
        'author' => 'rchavik',
        array('attribute' => 'og:author', 'content' => 'rchavik'),
        array('http-equiv' => 'refresh', 'content' => '5'),
    ));
```

To generate:

``` html
    <meta name="author" content="rchavik">
    <meta attribute="og:author" content="rchavik">
    <meta http-equiv="refresh" content="5">
```
