### PR TITLE
Fixed fallback view rendered when overriding view existed. refs #408 

### DIFF
--- a/Croogo/Controller/CroogoAppController.php
+++ b/Croogo/Controller/CroogoAppController.php
@@ -382,21 +382,26 @@ class CroogoAppController extends Controller {
 	}
 
 	private function __formatThemesPaths($rowThemesPath) {
-		$themesPath = current(array_filter(Hash::extract($rowThemesPath, '{n}.{n}')));
-		foreach ($themesPath as &$path) {
-			$path .= DS;
-		}
+		$themesPath = array();
+		if (!empty($rowThemesPath)) {
+			$themesPath = current(array_filter(Hash::extract($rowThemesPath, '{n}.{n}')));
 
+			foreach ($themesPath as $index => $path) {
+				$themesPath[$index] = $path . DS;
+			}
+		}
 		return $themesPath;
 	}
 
 	private function __findRequestedViewIn($viewPaths)
 	{
-		foreach ($viewPaths as $path) {
-			$requested = $path . $this->viewPath . DS . $this->request->action . '.ctp';
-			if (file_exists($requested)) {
-				return $requested;
-			};
+	    if (!empty($viewPaths)) {
+			foreach ($viewPaths as $path) {
+				$requested = $path . $this->viewPath . DS . $this->request->action . '.ctp';
+				if (file_exists($requested)) {
+					return $requested;
+				};
+			}
 		}
 		return false;
 	}

--- a/Croogo/Test/Case/Controller/CroogoAppControllerTest.php
+++ b/Croogo/Test/Case/Controller/CroogoAppControllerTest.php
@@ -71,21 +71,8 @@ class CroogoAppControllerTest extends CroogoControllerTestCase {
 			'return' => 'contents',
 		));
 
-		$this->assertContains('<h1>I should be displayed</h1>', trim($result));
 		$File->delete();
-	}
-
-	public function testRenderOverridenAdminView() {
-		$filePath = $this->__getOverridenViewPath();
-
-		$File = $this->__generateOverridenAdminView($filePath);
-
-		$result = $this->testAction('/admin/nodes/nodes/edit', array(
-			'return' => 'contents',
-		));
-
 		$this->assertContains('<h1>I should be displayed</h1>', trim($result));
-		$File->delete();
 	}
 
 /**


### PR DESCRIPTION
There was an issue when trying to override admin_add/edit, automatically admin_form came arround as fallback.

This should fix it (I provided a test for overriding view in themes)
