### PR TITLE
Fix problems where adminMenus method is passed a url as string

### DIFF
--- a/Croogo/View/Helper/CroogoHelper.php
+++ b/Croogo/View/Helper/CroogoHelper.php
@@ -115,7 +115,7 @@ class CroogoHelper extends AppHelper {
 				$out .= $this->Html->tag('li', null, $liOptions);
 				continue;
 			}
-			if ($currentRole != 'admin' && !$this->{$aclPlugin}->linkIsAllowedByUserId($userId, $menu['url'])) {
+			if (is_array($menu['url']) &&  $currentRole != 'admin' && !$this->{$aclPlugin}->linkIsAllowedByUserId($userId, $menu['url'])) {
 				continue;
 			}
 


### PR DESCRIPTION
Fix problems where adminMenus method is passed a url as string but can only deal with arrays
