### PR TITLE
Fix: NodesHelper::url() signature mismatch in php 5.4

### DIFF
--- a/Nodes/Test/Case/View/Helper/NodesHelperTest.php
+++ b/Nodes/Test/Case/View/Helper/NodesHelperTest.php
@@ -53,4 +53,29 @@ class NodesHelperTest extends CroogoTestCase {
 		$this->assertContains('class="node-list"', $content);
 	}
 
+/**
+ * Test NodesHelper::url()
+ */
+	public function testNodesUrl() {
+		$result = $this->Nodes->url(null);
+		$this->assertEquals('/', $result);
+
+		$result = $this->Nodes->url('/page/about');
+		$this->assertEquals('/page/about', $result);
+
+		$node = array(
+			'Node' => array(
+				'type' => 'page',
+				'slug' => 'about',
+			)
+		);
+		$result = $this->Nodes->url($node);
+		$expected = '/nodes/nodes/view/type:page/slug:about';
+		$this->assertEquals($expected, $result);
+
+		$fullBaseUrl = Configure::read('App.fullBaseUrl');
+		$result = $this->Nodes->url($node, true);
+		$this->assertEquals($fullBaseUrl . $expected, $result);
+	}
+
 }

--- a/Nodes/View/Helper/NodesHelper.php
+++ b/Nodes/View/Helper/NodesHelper.php
@@ -241,17 +241,23 @@ class NodesHelper extends AppHelper {
  * @param array $node Node data
  * @return string
  */
-	public function url($node = array()) {
-		if (empty($node)) {
-			$node = $this->node;
+	public function url($url = null, $full = false) {
+		if ($url === null && $this->node) {
+			$url = $this->node;
 		}
-		return $this->Html->url(array(
-			'plugin' => 'nodes',
-			'controller' => 'nodes',
-			'action' => 'view',
-			'type' => $node['Node']['type'],
-			'slug' => $node['Node']['slug']
-		));
+		$alias = is_array($url) ? key($url) : null;
+		if (isset($url[$alias]['url'])) {
+			$url = $url[$alias]['url'];
+		} elseif (isset($url[$alias]['type']) && isset($url[$alias]['slug'])) {
+			$url = array(
+				'plugin' => 'nodes',
+				'controller' => 'nodes',
+				'action' => 'view',
+				'type' => $url[$alias]['type'],
+				'slug' => $url[$alias]['slug']
+			);
+		}
+		return parent::url($url, $full);
 	}
 
 }


### PR DESCRIPTION
Adapt to use `url` key populated by UrlBehavior when available

Improves #426
