### PR TITLE
2.0 acl

### DIFF
--- a/Acl/View/Helper/AclHelper.php
+++ b/Acl/View/Helper/AclHelper.php
@@ -151,8 +151,17 @@ class AclHelper extends Helper {
 			$path = $url;
 		}
 		$linkAction = str_replace('//', '/', $path);
+
 		if (in_array($linkAction, $this->getAllowedActionsByUserId($userId))) {
 			return true;
+		} else {
+			$userAro = array('model' => 'User', 'foreign_key' => $userId);
+			$nodes = $this->AclPermission->Aro->node($userAro);
+			if (isset($nodes[0]['Aro'])) {
+				if ($this->AclPermission->check($nodes[0]['Aro'], $linkAction)) {
+					return true;
+				}
+			}
 		}
 		return false;
 	}


### PR DESCRIPTION
This requires cakephp > 2.5.0 which is not released.

The commit we need is cakephp/cakephp@b83b59a9d7d21c35a512182ab923a586c7c6bb6b. Without that commit, we'll have `trigger_error()`ed all over the place.
