### PR TITLE
Use Croogo.bootstrapComplete event to start editor setup

### DIFF
--- a/Wysiwyg/Config/bootstrap.php
+++ b/Wysiwyg/Config/bootstrap.php
@@ -1,3 +1,0 @@
-<?php
-
-Croogo::hookHelper('*', 'Wysiwyg.Wysiwyg');

--- a/Wysiwyg/Config/events.php
+++ b/Wysiwyg/Config/events.php
@@ -1,0 +1,7 @@
+<?php
+
+$config = array(
+	'EventHandlers' => array(
+		'Wysiwyg.WysiwygEventHandler',
+	),
+);

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
 	"require": {
 		"php": ">=5.3.0",
 		"composer/installers": "~1.0",
-		"croogo/Ckeditor": "~1.0",
+		"croogo/Ckeditor": "~2.0",
 		"cakedc/search": "dev-master",
 		"cakedc/migrations": "~2.2"
 	},


### PR DESCRIPTION
Since `Wysiwyg.actions` has been setup by every plugin bootstrap.php,
attaching helpers now does not depend on plugin load order.

Closes #409
