### PR TITLE
Avoid losing `locale` in redirects

### DIFF
--- a/Plugin/Croogo/Controller/CroogoAppController.php
+++ b/Plugin/Croogo/Controller/CroogoAppController.php
@@ -167,6 +167,26 @@ class CroogoAppController extends Controller {
 	}
 
 /**
+ * Avoid losing 'locale' in redirects
+ *
+ * @see Controller::beforeRedirect()
+ */
+	public function beforeRedirect($url, $status, $exit = true) {
+		if (isset($this->request->params['locale'])) {
+			if (is_string($url)) {
+				$url = array(
+					'url' => '/' . $this->request->params['locale'] . $url,
+					'status' => $status,
+					'exit' => $exit,
+				);
+			} elseif (isset($url['url'])) {
+				$url['url']['locale'] = $this->request->params['locale'];
+			}
+		}
+		return $url;
+	}
+
+/**
  * blackHoleCallback for SecurityComponent
  *
  * @return void


### PR DESCRIPTION
Although this adds a new method, I don't think this breaks semver because the method exists in parent class.

Aside from that, anyone see any problem with this patch?

Closes #453
