### PR TITLE
Fixed: delete meta field

### DIFF
--- a/Meta/View/Helper/MetaHelper.php
+++ b/Meta/View/Helper/MetaHelper.php
@@ -112,11 +112,10 @@ class MetaHelper extends AppHelper {
 		$fields = $this->Html->tag('div', $fields, array('class' => 'fields'));
 
 		$id = is_null($id) ? $uuid : $id;
-		$deleteUrl = array_intersect_key($this->request->params, array(
-			'admin' => null, 'plugin' => null,
-			'controller' => null, 'named' => null,
-		));
-		$deleteUrl['action'] = 'delete_meta';
+		$deleteUrl = array(
+			'admin' => true, 'plugin' => 'meta',
+			'controller' => 'meta', 'action' => 'delete_meta'
+		);
 		$deleteUrl[] = $id;
 		$actions = $this->Html->link(
 			__d('croogo', 'Remove'),

--- a/Nodes/Controller/NodesController.php
+++ b/Nodes/Controller/NodesController.php
@@ -289,7 +289,9 @@ class NodesController extends NodesAppController {
 			}
 		}
 
+		$success = array('success' => $success);
 		$this->set(compact('success'));
+		$this->set('_serialize', 'success');
 	}
 
 /**


### PR DESCRIPTION
Meta delete url changed from NodesController::admin_delete_meta() to MetaController::admin_delete_meta() .
NodesController::admin_delete_meta() was deprecate and has been deleted.
