### PR TITLE
Refactor Users plugin User model to use alias

### DIFF
--- a/Users/Model/User.php
+++ b/Users/Model/User.php
@@ -174,7 +174,7 @@ class User extends UsersAppModel {
 		if ($this->field('role_id') == $adminRoleId) {
 			$count = $this->find('count', array(
 				'conditions' => array(
-					$this->escapeField().' <>' => $this->id,
+					$this->escapeField() . ' <>' => $this->id,
 					$this->escapeField('role_id') => $adminRoleId,
 					$this->escapeField('status') => true,
 				)


### PR DESCRIPTION
This fix will allow extending the User model from the Users plugin to any custom model without the need to worry about using the proper aliases.
