### PR TITLE
Auth->loginRedirect = Config::read(Croogo.dashboardUrl)

### DIFF
--- a/Acl/Controller/Component/AclFilterComponent.php
+++ b/Acl/Controller/Component/AclFilterComponent.php
@@ -134,11 +134,7 @@ class AclFilterComponent extends Component {
 			'controller' => 'users',
 			'action' => 'login',
 		);
-		$this->_controller->Auth->loginRedirect = array(
-			'plugin' => 'settings',
-			'controller' => 'settings',
-			'action' => 'dashboard',
-		);
+		$this->_controller->Auth->loginRedirect = Configure::read('Croogo.dashboardUrl');
 		$this->_controller->Auth->unauthorizedRedirect = array(
 			'plugin' => 'users',
 			'controller' => 'users',


### PR DESCRIPTION
Swap hard coded loginRedirect Url for new Croogo.dashboardUrl setting.  Deals with one of the problems detailed in issue:
https://github.com/croogo/croogo/issues/503#issuecomment-48159250
