### PR TITLE
Add method: output rendered block

### DIFF
--- a/Blocks/View/Helper/RegionsHelper.php
+++ b/Blocks/View/Helper/RegionsHelper.php
@@ -30,6 +30,73 @@ class RegionsHelper extends AppHelper {
 			return true;
 		}
 	}
+	
+/**
+ * Show Block
+ *
+ * By default block is rendered using Blocks.block element. If `Block.element` is
+ * set and exists, the render process will pass it through given element before wrapping
+ * it inside the Blocks.block container. You disable the wrapping by setting
+ * `enclosure=false` in the `params` field.
+ *
+ * @param string $blockAlias Block alias
+ * @param array $options
+ * @return string
+ */
+	public function block($blockAlias, $options = array()) {
+		$output = '';
+		if (!$blockAlias) {
+			return $output;
+		}
+
+		$options = Hash::merge(array(
+			'elementOptions' => array(),
+		), $options);
+		$elementOptions = $options['elementOptions'];
+
+		$defaultElement = 'Blocks.block';
+		$blocks = Hash::combine($this->_View->viewVars['blocks_for_layout'], '{s}.{n}.Block.alias', '{s}.{n}');
+		if (!isset($blocks[$blockAlias])) {
+			return $output;
+		}
+		$block = $blocks[$blockAlias];
+		
+		$element = $block['Block']['element'];
+		$exists = $this->_View->elementExists($element);
+		$blockOutput = '';
+
+		Croogo::dispatchEvent('Helper.Regions.beforeSetBlock', $this->_View, array(
+			'content' => &$block['Block']['body'],
+		));
+
+		if ($exists) {
+			$blockOutput = $this->_View->element($element, compact('block'), $elementOptions);
+		} else {
+			if (!empty($element)) {
+				$this->log(sprintf('Missing element `%s` in block `%s` (%s)',
+					$block['Block']['element'],
+					$block['Block']['alias'],
+					$block['Block']['id']
+				), LOG_WARNING);
+			}
+			$blockOutput = $this->_View->element($defaultElement, compact('block'), array('ignoreMissing' => true) + $elementOptions);
+		}
+
+		Croogo::dispatchEvent('Helper.Regions.afterSetBlock', $this->_View, array(
+			'content' => &$blockOutput,
+		));
+
+		$enclosure = isset($block['Params']['enclosure']) ? $block['Params']['enclosure'] === "true" : true;
+		if ($exists && $element != $defaultElement && $enclosure) {
+			$block['Block']['body'] = $blockOutput;
+			$block['Block']['element'] = null;
+			$output .= $this->_View->element($defaultElement, compact('block'), $elementOptions);
+		} else {
+			$output .= $blockOutput;
+		}
+
+		return $output;
+	}
 
 /**
  * Show Blocks for a particular Region


### PR DESCRIPTION
The ability to call a block from with a block or node added in v2(https://github.com/croogo/croogo/commit/b131edc53bebe27422f5e437f6301541bd219b70) is great, but it only replaces the block shortcode with the body field.  What if the title needs displaying or the block uses a custom element? 

I propose a new RegionsHelper method that uses similar logic to the blocks() method, taking data from blocks_for_layout and outputting a single rendered block.  This can then be called from places like Blocks  EventHandler::filterBlockShortcode().
