### PR TITLE
Change admin_add/admin_edit to use saveAll

### DIFF
--- a/Blocks/Controller/BlocksController.php
+++ b/Blocks/Controller/BlocksController.php
@@ -125,7 +125,7 @@ class BlocksController extends BlocksAppController {
 			$this->Block->create();
 			$this->request->data['Block']['visibility_roles'] = $this->Block->encodeData($this->request->data['Role']['Role']);
 			$this->request->data['Block']['visibility_paths'] = $this->Block->encodeData(explode("\n", $this->request->data['Block']['visibility_paths']));
-			if ($this->Block->save($this->request->data)) {
+			if ($this->Block->saveAll($this->request->data)) {
 				$this->Session->setFlash(__d('croogo', 'The Block has been saved'), 'default', array('class' => 'success'));
 				$this->Croogo->redirect(array('action' => 'edit', $this->Block->id));
 			} else {
@@ -154,7 +154,7 @@ class BlocksController extends BlocksAppController {
 		if (!empty($this->request->data)) {
 			$this->request->data['Block']['visibility_roles'] = $this->Block->encodeData($this->request->data['Role']['Role']);
 			$this->request->data['Block']['visibility_paths'] = $this->Block->encodeData(explode("\n", $this->request->data['Block']['visibility_paths']));
-			if ($this->Block->save($this->request->data)) {
+			if ($this->Block->saveAll($this->request->data)) {
 				$this->Session->setFlash(__d('croogo', 'The Block has been saved'), 'default', array('class' => 'success'));
 				$this->Croogo->redirect(array('action' => 'edit', $id));
 			} else {


### PR DESCRIPTION
Related to issue https://github.com/croogo/croogo/issues/514#issuecomment-53711274

This change allows a user to extend the blocks plugin and save related data in another table.  Handy if you want blocks to have site specific fields so they can become a lot more flexible for clients.

I will release a plugin that demonstrates this soon.
