### PR TITLE
Fix issue with view paths and RSS feeds

### DIFF
--- a/Croogo/Controller/Component/CroogoComponent.php
+++ b/Croogo/Controller/Component/CroogoComponent.php
@@ -444,7 +444,7 @@ class CroogoComponent extends Component {
 		$viewPaths = $this->_setupViewPaths($controller);
 		foreach ($views as $view) {
 			foreach ($viewPaths as $viewPath) {
-				$viewPath = $viewPath . $controller->name . DS . $view . $controller->ext;
+				$viewPath = $viewPath . $controller->viewPath . DS . $view . $controller->ext;
 				if (file_exists($viewPath)) {
 					$controller->view = $viewPath;
 					return;


### PR DESCRIPTION
Due to the CroogoComponent::viewFallback() method using `$controller->name` under certain conditions the correct rss/ view file would not be called.
If, for example a index_blog.ctp file exists in the theme, Croogo would render `View/Themed/ThemeName/Plugin/Nodes/Nodes/index_blog.ctp` instead of the correct rss/index.ctp file (In the case of a .rss request).

This commit corrects that by using the `$controler->viewPath` property instead.
