### PR TITLE
Remove view variable escaping in CroogoErrorController

### DIFF
--- a/Croogo/Controller/CroogoErrorController.php
+++ b/Croogo/Controller/CroogoErrorController.php
@@ -79,18 +79,4 @@ class CroogoErrorController extends AppController {
 		}
 	}
 
-/**
- * Escapes the viewVars.
- *
- * @return void
- */
-	public function beforeRender() {
-		parent::beforeRender();
-		foreach ($this->viewVars as $key => $value) {
-			if (!is_object($value)) {
-				$this->viewVars[$key] = h($value);
-			}
-		}
-	}
-
 }


### PR DESCRIPTION
Follows on from the same change in CakePHP - https://github.com/cakephp/cakephp/commit/8931b74ba2c3085c28ffdb8767b1400aeef278d0
