### PR TITLE
Prevents infinite redirects due to ACL misconfiguration

### DIFF
--- a/Croogo/Controller/Component/CroogoComponent.php
+++ b/Croogo/Controller/Component/CroogoComponent.php
@@ -266,7 +266,7 @@ class CroogoComponent extends Component {
 		$aco = implode('/', array_filter(array(
 			$controller->plugin, $controller->name, $controller->action
 		)));
-		if ($user['id'] && !$controller->Acl->check($aro, $aco)) {
+		if ($user['id'] && $user['role_id'] != 1 && !$controller->Acl->check($aro, $aco)) {
 			$this->log(sprintf('Redirect abort: %s - no access to: %s', $user['username'], $aco));
 			$url = '/';
 		}


### PR DESCRIPTION
Addresses issues discussed in #503

I don't like the hardcoded `User` value for aro and changing the supplied $url to `/` but I don't see any other way to do it.  Don't see much value in making those configurable.

But, do we really need this? This is most likely caused due to ACL misconfiguration and the problem goes away once the configuration is corrected.

Also, any security considerations? 
