### PR TITLE
Adds attachment choosers (Image and File) on the setupLinkChooser event

### DIFF
--- a/FileManager/Config/events.php
+++ b/FileManager/Config/events.php
@@ -1,0 +1,7 @@
+<?php
+
+$config = array(
+	'EventHandlers' => array(
+		'FileManager.FileManagerEventHandler',
+	),
+);

--- a/FileManager/Controller/AttachmentsController.php
+++ b/FileManager/Controller/AttachmentsController.php
@@ -17,6 +17,24 @@ App::uses('FileManagerAppController', 'FileManager.Controller');
 class AttachmentsController extends FileManagerAppController {
 
 /**
+ * Components
+ *
+ * @var array
+ * @access public
+ */
+	public $components = array(
+		'Search.Prg' => array(
+			'presetForm' => array(
+				'paramType' => 'querystring',
+			),
+			'commonProcess' => array(
+				'paramType' => 'querystring',
+				'filterEmpty' => true,
+			),
+		),
+	);
+
+/**
  * Models used by the Controller
  *
  * @var array
@@ -97,10 +115,34 @@ class AttachmentsController extends FileManagerAppController {
  */
 	public function admin_index() {
 		$this->set('title_for_layout', __d('croogo', 'Attachments'));
+		$this->Prg->commonProcess();
+
+		$isChooser = false;
+		if (isset($this->request->params['named']['links']) || isset($this->request->query['chooser'])) {
+			$isChooser = true;
+		}
 
 		$this->Attachment->recursive = 0;
+
 		$this->paginate['Attachment']['order'] = 'Attachment.created DESC';
-		$this->set('attachments', $this->paginate());
+		$this->paginate['Attachment']['conditions'] = array();
+		if ($isChooser) {
+			if ($this->request->query['chooser_type'] == 'image') {
+				$this->paginate['Attachment']['conditions']['Attachment.mime_type LIKE'] = 'image/%';
+			} else {
+				$this->paginate['Attachment']['conditions']['Attachment.mime_type NOT LIKE'] = 'image/%';
+			}
+		}
+
+		$criteria = $this->Attachment->parseCriteria($this->Prg->parsedParams());
+		$this->set('attachments', $this->paginate($criteria));
+		$this->set('uploadsDir', $this->Attachment->uploadsDir);
+
+		if ($isChooser) {
+			$this->layout = 'admin_popup';
+			$this->render('admin_chooser');
+		}
+
 	}
 
 /**

--- a/FileManager/Event/FileManagerEventHandler.php
+++ b/FileManager/Event/FileManagerEventHandler.php
@@ -5,6 +5,7 @@ App::uses('CakeEventListener', 'Event');
 /**
  * FileManagerEventHandler
  *
+ * @category Event
  * @package  Croogo.FileManager.Event
  * @license  http://www.opensource.org/licenses/mit-license.php The MIT License
  * @link     http://www.croogo.org
@@ -15,7 +16,55 @@ class FileManagerEventHandler implements CakeEventListener {
  * implementedEvents
  */
 	public function implementedEvents() {
-		return array();
+		return array(
+			'Controller.Links.setupLinkChooser' => array(
+				'callable' => 'onSetupLinkChooser',
+			),
+		);
+	}
+
+/**
+ * Setup Link chooser values
+ *
+ * @return void
+ */
+	public function onSetupLinkChooser($event) {
+		$linkChoosers = array();
+		$linkChoosers['Images'] = array(
+			'title' => 'Images',
+			'description' => 'Attachments with an image mime type.',
+			'url' => array(
+				'plugin' => 'file_manager',
+				'controller' => 'attachments',
+				'action' => 'index',
+				'?' => array(
+					'chooser_type' => 'image',
+					'chooser' => 1,
+					'KeepThis' => true,
+					'TB_iframe' => true,
+					'height' => 400,
+					'width' => 600
+				)
+			)
+		);
+		$linkChoosers['Files'] = array(
+			'title' => 'Files',
+			'description' => 'Attachments with other mime types, ie. pdf, xls, doc, etc.',
+			'url' => array(
+				'plugin' => 'file_manager',
+				'controller' => 'attachments',
+				'action' => 'index',
+				'?' => array(
+					'chooser_type' => 'file',
+					'chooser' => 1,
+					'KeepThis' => true,
+					'TB_iframe' => true,
+					'height' => 400,
+					'width' => 600
+				)
+			)
+		);
+		Croogo::mergeConfig('Menus.linkChoosers', $linkChoosers);
 	}
 
 }

--- a/FileManager/View/Attachments/admin_chooser.ctp
+++ b/FileManager/View/Attachments/admin_chooser.ctp
@@ -1,0 +1,77 @@
+<div class="<?php echo $this->Layout->cssClass('row'); ?>">
+	<div class="<?php echo $this->Layout->cssClass('columnFull'); ?>">
+	<?php
+		echo __d('croogo', 'Sort by:');
+		echo ' ' . $this->Paginator->sort('id', __d('croogo', 'Id'), array('class' => 'sort'));
+		echo ', ' . $this->Paginator->sort('title', __d('croogo', 'Title'), array('class' => 'sort'));
+		echo ', ' . $this->Paginator->sort('created', __d('croogo', 'Created'), array('class' => 'sort'));
+	?>
+	</div>
+</div>
+
+<div class="<?php echo $this->Layout->cssClass('row'); ?>">
+	<div class="<?php echo $this->Layout->cssClass('columnFull'); ?>">
+		<?php echo $this->element('FileManager.admin/attachments_search'); ?>
+		<hr />
+	</div>
+</div>
+
+<div class="<?php echo $this->Layout->cssClass('row'); ?>">
+	<div class="<?php echo $this->Layout->cssClass('columnFull'); ?>">
+		<ul id="attachments-for-links">
+		<?php foreach ($attachments as $attachment) { ?>
+			<li>
+			<?php
+				echo $this->Html->link($attachment['Attachment']['title'],
+					"/{$uploadsDir}/" . $attachment['Attachment']['slug'],
+				array(
+					'class' => 'item-choose',
+					'data-chooser_type' => 'Node',
+					'data-chooser_id' => $attachment['Attachment']['id'],
+					'data-chooser_title' => $attachment['Attachment']['title'],
+					'rel' => sprintf(
+						"/{$uploadsDir}/%s",
+						$attachment['Attachment']['slug']
+					),
+				));
+
+				$popup = array();
+				$type = __d('croogo', $attachment['Attachment']['mime_type']);
+				$popup[] = array(
+					__d('croogo', 'Promoted'),
+					$this->Layout->status($attachment['Attachment']['promote'])
+				);
+				$popup[] = array(
+					__d('croogo', 'Status'),
+					$this->Layout->status($attachment['Attachment']['status'])
+				);
+				$popup[] = array(
+					__d('croogo', 'Created'),
+					array($this->Time->niceShort($attachment['Attachment']['created']), array('class' => 'nowrap'))
+				);
+				$popup = $this->Html->tag('table', $this->Html->tableCells($popup), array(
+					'class' => 'table table-condensed',
+				));
+				$a = $this->Html->link('', '#', array(
+					'class' => 'popovers action',
+					'icon' => $_icons['info-sign'],
+					'data-title' => $type,
+					'data-trigger' => 'click',
+					'data-placement' => 'right',
+					'data-html' => true,
+					'data-content' => h($popup),
+				));
+				echo $a;
+			?>
+			</li>
+		<?php } ?>
+		</ul>
+		<?php echo $this->element('admin/pagination'); ?>
+	</div>
+</div>
+<?php
+
+$script =<<<EOF
+$('.popovers').popover().on('click', function() { return false; });;
+EOF;
+$this->Js->buffer($script);

--- a/FileManager/View/Elements/admin/attachments_search.ctp
+++ b/FileManager/View/Elements/admin/attachments_search.ctp
@@ -1,0 +1,59 @@
+<?php
+
+$url = isset($url) ? $url : array('action' => 'index');
+$chooserType = isset($this->request->query['chooser_type']) ? $this->request->query['chooser_type'] : 'attachment';
+
+?>
+<div class="clearfix filter">
+<?php
+	echo $this->Form->create('Attachment', array(
+		'class' => 'form-inline',
+		'url' => $url,
+		'inputDefaults' => array(
+			'label' => false,
+		),
+	));
+
+	echo $this->Form->input('chooser_type', array(
+		'type' => 'hidden',
+		'value' => $chooserType,
+	));
+
+	echo $this->Form->input('chooser', array(
+		'type' => 'hidden',
+		'value' => isset($this->request->query['chooser']),
+	));
+
+	echo $this->Form->input('filter', array(
+		'title' => __d('croogo', 'Search'),
+		'placeholder' => __d('croogo', 'Search...'),
+		'tooltip' => false,
+	));
+
+	if (!isset($this->request->query['chooser'])):
+
+		echo $this->Form->input('status', array(
+			'options' => array(
+				'1' => __d('croogo', 'Published'),
+				'0' => __d('croogo', 'Unpublished'),
+			),
+			'empty' => __d('croogo', 'Status'),
+		));
+
+		echo $this->Form->input('promote', array(
+			'options' => array(
+				'1' => __d('croogo', 'Yes'),
+				'0' => __d('croogo', 'No'),
+			),
+			'empty' => __d('croogo', 'Promoted'),
+		));
+
+	endif;
+
+	echo $this->Form->submit(__d('croogo', 'Filter'), array(
+		'button' => 'default',
+		'div' => false,
+	));
+	echo $this->Form->end();
+?>
+</div>


### PR DESCRIPTION
This allows attachments to be the target of a link in a menu collection. For example, you can link from a menu item directly to a pdf attachment. Without this you could only select content / articles.

Reference #574.
