### PR TITLE
Fix filter published nodes

### DIFF
--- a/Croogo/Lib/CroogoStatus.php
+++ b/Croogo/Lib/CroogoStatus.php
@@ -45,7 +45,7 @@ class CroogoStatus implements ArrayAccess {
 				self::PENDING => __d('croogo', 'Pending'),
 			),
 		);
-		$event = Croogo::dispatchEvent('Croogo.Status.setup', null, $this);
+		Croogo::dispatchEvent('Croogo.Status.setup', null, $this);
 	}
 
 	public function offsetExists($offset) {

--- a/Nodes/Model/Node.php
+++ b/Nodes/Model/Node.php
@@ -65,6 +65,8 @@ class Node extends NodesAppModel {
  */
 	const UNPROCESSED_ACTION = 'delete';
 
+	const DEFAULT_VISIBILITY_ROLE = 3;
+
 /**
  * Behaviors used by the Model
  *
@@ -291,6 +293,7 @@ class Node extends NodesAppModel {
 		$conditions = array();
 		if (!empty($data['filter'])) {
 			$filter = '%' . $data['filter'] . '%';
+			$visibilityRolesField = $this->escapeField('visibility_roles');
 			$conditions = array(
 				$this->escapeField('status') => $this->status(),
 				'AND' => array(
@@ -303,9 +306,10 @@ class Node extends NodesAppModel {
 						),
 					),
 					array(
-						$visibilityRolesField => '',
-						$visibilityRolesField . ' LIKE' => '%"' . $this->Croogo->roleId() . '"%',
-
+						'OR' => array(
+							array($visibilityRolesField . ' LIKE' => '%"' . self::DEFAULT_VISIBILITY_ROLE . '"%'),
+							array($visibilityRolesField => ''),
+						)
 					),
 				),
 			);
@@ -321,8 +325,6 @@ class Node extends NodesAppModel {
  * @return mixed see Model::saveAll()
  */
 	public function saveNode($data, $typeAlias = self::DEFAULT_TYPE) {
-		$result = false;
-
 		$data = $this->formatData($data, $typeAlias);
 		$event = Croogo::dispatchEvent('Model.Node.beforeSaveNode', $this, compact('data', 'typeAlias'));
 

--- a/Nodes/Test/Case/Model/NodeTest.php
+++ b/Nodes/Test/Case/Model/NodeTest.php
@@ -405,6 +405,16 @@ class NodeTest extends CroogoTestCase {
 		$this->assertEquals(3, count($nodes));
 	}
 
+	public function testFilterPublishedNodes() {
+		$this->Node->id = 3;
+		$this->assertTrue((bool)$this->Node->saveField('status', CroogoStatus::UNPUBLISHED));
+
+		$filterConditions = $this->Node->filterPublishedNodes(array('filter' => 'This'));
+
+		$nodes = $this->Node->find('all', array('conditions' => $filterConditions));
+		$this->assertEquals(2, count($nodes));
+	}
+
 /**
  * test updateAllNodesPaths
  */


### PR DESCRIPTION
Node::filterPublishedNodes method was broken since it was created (https://github.com/croogo/croogo/commit/a397845c448465cbaa1db422217d782571f6f706).

Undefined variable for `$visibilityRoleFields`. I quickly wrote down a (basic) test to ensure method is working fine. 
