### PR TITLE
264 restrict default file editor path to uploads

### DIFF
--- a/FileManager/Controller/FileManagerController.php
+++ b/FileManager/Controller/FileManagerController.php
@@ -104,12 +104,7 @@ class FileManagerController extends FileManagerAppController {
  */
 	public function admin_browse() {
 		$this->folder = new Folder;
-
-		if (isset($this->request->query['path'])) {
-			$path = $this->request->query['path'];
-		} else {
-			$path = APP;
-		}
+		$path = $this->__getPath();
 
 		$this->set('title_for_layout', __d('croogo', 'File Manager'));
 
@@ -176,13 +171,8 @@ class FileManagerController extends FileManagerAppController {
  */
 	public function admin_upload() {
 		$this->set('title_for_layout', __d('croogo', 'Upload'));
+		$path = $this->__getPath();
 
-		if (isset($this->request->query['path'])) {
-			$path = $this->request->query['path'];
-		} else {
-			$path = APP;
-		}
-		$this->set(compact('path'));
 		if (isset($path) && !$this->FileManager->isDeletable($path)) {
 			$this->Session->setFlash(__d('croogo', 'Path %s is restricted', $path), 'flash', array('class' => 'error'));
 			return $this->redirect($this->referer());
@@ -384,11 +374,24 @@ class FileManagerController extends FileManagerAppController {
 
 /**
  * Admin chmod
- *
+ * @TODO Create FileManager::chmod method and use it through this action.
  * @return void
  * @access public
  */
 	public function admin_chmod() {
+	}
+
+	/**
+	 * @return string
+	 */
+	private function __getPath() {
+		if (isset($this->request->query['path'])) {
+			$path = $this->request->query['path'];
+		} else {
+			$path = $this->FileManager->getDefaultBrowsingPath();
+		}
+		$this->set(compact('path'));
+		return $path;
 	}
 
 }

--- a/FileManager/Controller/FileManagerController.php
+++ b/FileManager/Controller/FileManagerController.php
@@ -49,10 +49,7 @@ class FileManagerController extends FileManagerAppController {
  */
 	public function beforeFilter() {
 		parent::beforeFilter();
-		$this->deletablePaths = array(
-			APP . 'View' . DS . 'Themed' . DS,
-			WWW_ROOT,
-		);
+		$this->deletablePaths = $this->FileManager->getDeletablePaths();
 		$this->set('deletablePaths', $this->deletablePaths);
 	}
 
@@ -116,9 +113,7 @@ class FileManagerController extends FileManagerAppController {
 
 		$this->set('title_for_layout', __d('croogo', 'File Manager'));
 
-		$path = realpath($path) . DS;
-		$regex = '/^' . preg_quote(realpath(APP), '/') . '/';
-		if (preg_match($regex, $path) == false) {
+		if (!$this->FileManager->isEditable($path) || !$this->FileManager->isDeletable($path)) {
 			$this->Session->setFlash(__d('croogo', 'Path %s is restricted', $path), 'flash', array('class' => 'error'));
 			$path = APP;
 		}
@@ -188,8 +183,7 @@ class FileManagerController extends FileManagerAppController {
 			$path = APP;
 		}
 		$this->set(compact('path'));
-
-		if (isset($path) && !$this->_isDeletable($path)) {
+		if (isset($path) && !$this->FileManager->isDeletable($path)) {
 			$this->Session->setFlash(__d('croogo', 'Path %s is restricted', $path), 'flash', array('class' => 'error'));
 			return $this->redirect($this->referer());
 		}
@@ -218,7 +212,7 @@ class FileManagerController extends FileManagerAppController {
 			return $this->redirect(array('controller' => 'file_manager', 'action' => 'browse'));
 		}
 
-		if (!$this->_isDeletable($path)) {
+		if (!$this->FileManager->isDeletable($path)) {
 			$this->Session->setFlash(__d('croogo', 'Path %s is restricted', $path), 'flash', array('class' => 'error'));
 			return $this->redirect(array('controller' => 'file_manager', 'action' => 'browse'));
 		}
@@ -251,7 +245,7 @@ class FileManagerController extends FileManagerAppController {
 			return $this->redirect(array('controller' => 'file_manager', 'action' => 'browse'));
 		}
 
-		if (isset($path) && !$this->_isDeletable($path)) {
+		if (isset($path) && !$this->FileManager->isDeletable($path)) {
 			$this->Session->setFlash(__d('croogo', 'Path %s is restricted', $path), 'flash', array('class' => 'error'));
 			return $this->redirect(array('controller' => 'file_manager', 'action' => 'browse'));
 		}

--- a/FileManager/Model/FileManager.php
+++ b/FileManager/Model/FileManager.php
@@ -22,7 +22,7 @@ class FileManager extends FileManagerAppModel {
 
 	public function __construct($id = false, $table = null, $ds = null) {
 		parent::__construct($id, $table, $ds);
-		$this->defaultBrowsingPath = APP . DS .  WEBROOT_DIR;
+		$this->defaultBrowsingPath = APP . DS .  WEBROOT_DIR .DS . 'uploads';
 	}
 
 /**

--- a/FileManager/Model/FileManager.php
+++ b/FileManager/Model/FileManager.php
@@ -16,6 +16,15 @@ class FileManager extends FileManagerAppModel {
 
 	public $useTable = false;
 
+	public $defaultBrowsingPath;
+	public $defaultEditablePaths = array();
+	public $defaultDeletablePaths = array();
+
+	public function __construct($id = false, $table = null, $ds = null) {
+		parent::__construct($id, $table, $ds);
+		$this->defaultBrowsingPath = APP . DS .  WEBROOT_DIR;
+	}
+
 /**
  * Checks wether given $path is editable
  *
@@ -26,11 +35,7 @@ class FileManager extends FileManagerAppModel {
  * @return boolean true if file is editable
  */
 	public function isEditable($path) {
-		$editablePaths = Configure::check('FileManager.editablePaths') ?
-			Configure::read('FileManager.editablePaths') :
-			array();
-
-		foreach ($editablePaths as $editablePath) {
+		foreach ($this->getEditablePaths() as $editablePath) {
 			if ($this->_isWithinPath($editablePath, $path)) {
 				return true;
 			}
@@ -49,11 +54,7 @@ class FileManager extends FileManagerAppModel {
  * @return boolean true when file is deletable
  */
 	public function isDeletable($path) {
-		$deletablePaths = Configure::check('FileManager.deletablePaths') ?
-			Configure::read('FileManager.deletablePaths') :
-			array();
-
-		foreach ($deletablePaths as $deletablePath) {
+		foreach ($this->getDeletablePaths() as $deletablePath) {
 			if ($this->_isWithinPath($deletablePath, $path)) {
 				return true;
 			}
@@ -91,4 +92,31 @@ class FileManager extends FileManagerAppModel {
 		return preg_match($regex, $path) > 0;
 	}
 
+/**
+ * @return array|mixed editable (writable) paths
+ */
+	public function getEditablePaths() {
+		return Configure::check('FileManager.editablePaths') ?
+			Configure::read('FileManager.editablePaths') :
+			$this->defaultEditablePaths;
+	}
+
+/**
+ * @return array|mixed deletable paths
+ */
+	public function getDeletablePaths () {
+		return Configure::check('FileManager.deletablePaths') ?
+			Configure::read('FileManager.deletablePaths') :
+			$this->defaultDeletablePaths;
+	}
+
+/**
+ * @default
+ * @return mixed|string Return the default path when browsing folder
+ */
+	public function getDefaultBrowsingPath() {
+		return Configure::check('FileManager.defaultBrowsePath') ?
+			Configure::read('FileManager.defaultBrowsePath') :
+			$this->defaultBrowsingPath;
+	}
 }

--- a/FileManager/Test/Case/Controller/FileManagerControllerTest.php
+++ b/FileManager/Test/Case/Controller/FileManagerControllerTest.php
@@ -86,6 +86,8 @@ class FileManagerControllerTest extends CroogoControllerTestCase {
  * @return void
  */
 	public function testAdminBrowse() {
+		Configure::write('FileManager.editablePaths', array(APP));
+		Configure::write('FileManager.deletablePaths', array(APP));
 		$url = '/admin/file_manager/file_manager/browse?path=' . urlencode(APP);
 		$request = new CakeRequest($url);
 		$response = new CakeResponse();

--- a/FileManager/Test/Case/Model/FileManagerTest.php
+++ b/FileManager/Test/Case/Model/FileManagerTest.php
@@ -28,7 +28,7 @@ class FileManagerTest extends CroogoTestCase {
  * @group isEditable
  */
 	public function testIsEditableShouldReturnTrueWhenPathIsWithinEditablePaths() {
-		$isEditable = $this->FileManager->isEditable($this->__testAppPath . DS . 'renameMeTooPlease.txt');
+		$isEditable = $this->FileManager->isEditable($this->__testAppPath . 'renameMeTooPlease.txt');
 		$this->assertTrue($isEditable);
 	}
 
@@ -85,8 +85,8 @@ class FileManagerTest extends CroogoTestCase {
  * @group rename
  */
 	public function testRenameShouldReturnedTrueOnSuccess() {
-		$oldPath = $this->__testAppPath . DS . 'renameMe';
-		$newPath = $this->__testAppPath . DS . 'renamed';
+		$oldPath = $this->__testAppPath . 'renameMe';
+		$newPath = $this->__testAppPath . 'renamed';
 
 		$this->assertTrue($this->FileManager->rename($oldPath, $newPath));
 		$this->FileManager->rename($newPath, $oldPath);
@@ -96,8 +96,8 @@ class FileManagerTest extends CroogoTestCase {
  * @group rename
  */
 	public function testRenameShouldRenamedOldFileToNewFile() {
-		$oldPath = $this->__testAppPath . DS . 'renameMeTooPlease.txt';
-		$newPath = $this->__testAppPath . DS . 'renamed.txt';
+		$oldPath = $this->__testAppPath . 'renameMeTooPlease.txt';
+		$newPath = $this->__testAppPath . 'renamed.txt';
 
 		$this->FileManager->rename($oldPath, $newPath);
 		$this->assertTrue(file_exists($newPath) && !file_exists($oldPath));

--- a/FileManager/Test/Case/Model/FileManagerTest.php
+++ b/FileManager/Test/Case/Model/FileManagerTest.php
@@ -40,6 +40,46 @@ class FileManagerTest extends CroogoTestCase {
 		$this->assertFalse($isEditable);
 	}
 
+	public function testGetEditablePaths() {
+		$expectedPaths = array('/foo/bar', '/no/pasaran');
+		Configure::write('FileManager.editablePaths', $expectedPaths);
+
+		$paths = $this->FileManager->getEditablePaths();
+		$this->assertEquals($expectedPaths, $paths);
+	}
+
+	public function testGetEditablePathsWithoutConfig() {
+		Configure::delete('FileManager.editablePaths');
+		$paths = $this->FileManager->getEditablePaths();
+		$this->assertEquals($this->FileManager->defaultEditablePaths, $paths);
+	}
+
+	public function testGetDeletablePaths() {
+		$expectedPaths = array('/foo/bar', '/nope/nope');
+		Configure::write('FileManager.deletablePaths', $expectedPaths);
+
+		$paths = $this->FileManager->getDeletablePaths();
+		$this->assertEquals($expectedPaths, $paths);
+	}
+
+	public function testGetDeletablePathsWithoutConfig() {
+		Configure::delete('FileManager.deletablePaths');
+		$paths = $this->FileManager->getDeletablePaths();
+		$this->assertEquals($this->FileManager->defaultDeletablePaths, $paths);
+	}
+
+	public function testGetDefaultBrowsingPath() {
+		$expectedPath = '/a/more/secure/path';
+		Configure::write('FileManager.defaultBrowsePath', $expectedPath);
+		$browsingPath = $this->FileManager->getDefaultBrowsingPath();
+
+		$this->assertEquals($expectedPath, $browsingPath);
+	}
+
+	public function testGetDefaultBrowsingPathWithoutConfig() {
+		$browsingPath = $this->FileManager->getDefaultBrowsingPath();
+		$this->assertEquals(APP. DS .WEBROOT_DIR, $browsingPath);
+	}
 
 /**
  * @group rename

--- a/FileManager/Test/Case/Model/FileManagerTest.php
+++ b/FileManager/Test/Case/Model/FileManagerTest.php
@@ -94,7 +94,7 @@ class FileManagerTest extends CroogoTestCase {
 
 	public function testGetDefaultBrowsingPathWithoutConfig() {
 		$browsingPath = $this->FileManager->getDefaultBrowsingPath();
-		$this->assertEquals(APP. DS .WEBROOT_DIR, $browsingPath);
+		$this->assertEquals($this->FileManager->defaultBrowsingPath, $browsingPath);
 	}
 
 /**

--- a/FileManager/Test/Case/Model/FileManagerTest.php
+++ b/FileManager/Test/Case/Model/FileManagerTest.php
@@ -40,6 +40,22 @@ class FileManagerTest extends CroogoTestCase {
 		$this->assertFalse($isEditable);
 	}
 
+/**
+ * @group isDeletable
+ */
+	public function testIsDeletable() {
+		$isDeletable = $this->FileManager->isDeletable($this->__testAppPath .  'renameMeTooPlease.txt');
+		$this->assertTrue($isDeletable);
+	}
+
+/**
+ * @group isDeletable
+ */
+	public function testIsDeletableOnRestrictedPath() {
+		$isDeletable = $this->FileManager->isDeletable('/usr/bin/php');
+		$this->assertFalse($isDeletable);
+	}
+
 	public function testGetEditablePaths() {
 		$expectedPaths = array('/foo/bar', '/no/pasaran');
 		Configure::write('FileManager.editablePaths', $expectedPaths);


### PR DESCRIPTION
By default prevent browsing whole Croogo App Dir and restrict to `uploads` folder within app webroot.
