### PR TITLE
Add button to reset current locale

### DIFF
--- a/Extensions/Controller/ExtensionsLocalesController.php
+++ b/Extensions/Controller/ExtensionsLocalesController.php
@@ -87,6 +87,21 @@ class ExtensionsLocalesController extends ExtensionsAppController {
 	}
 
 /**
+ * Reset to default locale
+ */
+	public function admin_reset_locale() {
+		if ($this->request->is('post')) {
+			$result = $this->Setting->write('Site.locale', null);
+			if ($result) {
+				$this->Session->setFlash(sprintf(__d('croogo', "Locale setting has been cleared"), $locale), 'flash', array('class' => 'success'));
+			} else {
+				$this->Session->setFlash(__d('croogo', 'Could not clear Locale setting.'), 'flash', array('class' => 'error'));
+			}
+		}
+		return $this->redirect($this->referer());
+	}
+
+/**
  * admin_add
  *
  * @return void

--- a/Extensions/View/ExtensionsLocales/admin_index.ctp
+++ b/Extensions/View/ExtensionsLocales/admin_index.ctp
@@ -11,6 +11,10 @@ $this->append('actions');
 	echo $this->Croogo->adminAction(__d('croogo', 'Upload'),
 		array('action' => 'add')
 	);
+	echo $this->Croogo->adminAction(__d('croogo', 'Reset'),
+		array('action' => 'reset_locale'),
+		array('method' => 'post')
+	);
 $this->end();
 
 $this->start('table-heading');

--- a/Extensions/View/ExtensionsLocales/admin_index.ctp
+++ b/Extensions/View/ExtensionsLocales/admin_index.ctp
@@ -11,7 +11,7 @@ $this->append('actions');
 	echo $this->Croogo->adminAction(__d('croogo', 'Upload'),
 		array('action' => 'add')
 	);
-	echo $this->Croogo->adminAction(__d('croogo', 'Reset'),
+	echo $this->Croogo->adminAction('Reset Locale',
 		array('action' => 'reset_locale'),
 		array('method' => 'post')
 	);


### PR DESCRIPTION
Much friendlier than changing to the Settings page and manually clearing
the Site.locale value.