### PR TITLE
Update form.ctp

### DIFF
--- a/Croogo/Console/Templates/croogo/views/form.ctp
+++ b/Croogo/Console/Templates/croogo/views/form.ctp
@@ -11,7 +11,7 @@ $header = <<<EOF
 
 if (\$this->action == 'admin_edit') {
 	\$this->Html->addCrumb(\$this->request->data['$modelClass']['$displayField'], '/' . \$this->request->url);
-	\$this->viewVars['title_for_layout'] = '$pluralHumanName: ' . \$this->request->data['$modelClass']['$displayField'];
+	\$this->viewVars['title_for_layout'] = __d('$underscoredPluginName', '$pluralHumanName') . ': ' . \$this->request->data['$modelClass']['$displayField'];
 } else {
 	\$this->Html->addCrumb(__d('croogo', 'Add'), '/' . \$this->request->url);
 }


### PR DESCRIPTION
Quick GH PR.

Prior example on admin_edit call:
```php
$this->viewVars['title_for_layout'] = 'Tariff Group Option Values: ' . $this->request->data['TariffGroupOptionValue']['id']; 
```
After fix:
```php
$this->viewVars['title_for_layout'] = __d('flexitariffs', 'Tariff Group Option Values') . ': ' . $this->request->data['TariffGroupOptionValue']['id'];
```
E.g. respects the plugin's translation file for the browser's title of the current model/controller.