### PR TITLE
Ignore created_by and updated_by in bake form view templates

### DIFF
--- a/Croogo/Console/Templates/croogo/views/form.ctp
+++ b/Croogo/Console/Templates/croogo/views/form.ctp
@@ -34,7 +34,7 @@ echo "\$this->append('tab-content');\n";
 	foreach ($fields as $field):
 		if ($field == $primaryKey):
 			continue;
-		elseif (!in_array($field, array('created', 'modified', 'updated'))):
+		elseif (!in_array($field, array('created', 'modified', 'updated', 'created_by', 'updated_by'))):
 			$fieldLabel = Inflector::humanize($field);
 			echo <<<EOF
 	echo \$this->Form->input('{$field}', array(


### PR DESCRIPTION
Ignores created_by and updated_by SQL fields in cake bake's form view templates.

These fields are now omitted from auto generation and thus by default not editable as they are being used Croogo.Trackable and even if not really don't sound like fields that should be user editable but rather always set by the application and/or database