### PR TITLE
form bake template translation and foreign key treatment

### DIFF
--- a/Croogo/Console/Templates/croogo/views/form.ctp
+++ b/Croogo/Console/Templates/croogo/views/form.ctp
@@ -35,7 +35,7 @@ echo "\$this->append('tab-content');\n";
 		if ($field == $primaryKey):
 			continue;
 		elseif (!in_array($field, array('created', 'modified', 'updated'))):
-			$fieldLabel = chop(chop($field, '_fk'), '_id');
+			$fieldLabel = chop($field, '_id');
 			$fieldLabel = Inflector::humanize($fieldLabel);
 			echo <<<EOF
 	echo \$this->Form->input('{$field}', array(

--- a/Croogo/Console/Templates/croogo/views/form.ctp
+++ b/Croogo/Console/Templates/croogo/views/form.ctp
@@ -35,7 +35,7 @@ echo "\$this->append('tab-content');\n";
 		if ($field == $primaryKey):
 			continue;
 		elseif (!in_array($field, array('created', 'modified', 'updated'))):
-			$fieldLabel = rtrim($field, '_id');
+			$fieldLabel = strrpos($field, '_id', -3) ? substr($field, 0, -3) : $field;
 			$fieldLabel = Inflector::humanize($fieldLabel);
 			echo <<<EOF
 	echo \$this->Form->input('{$field}', array(

--- a/Croogo/Console/Templates/croogo/views/form.ctp
+++ b/Croogo/Console/Templates/croogo/views/form.ctp
@@ -35,7 +35,7 @@ echo "\$this->append('tab-content');\n";
 		if ($field == $primaryKey):
 			continue;
 		elseif (!in_array($field, array('created', 'modified', 'updated'))):
-			$fieldLabel = chop($field, '_id');
+			$fieldLabel = rtrim($field, '_id');
 			$fieldLabel = Inflector::humanize($fieldLabel);
 			echo <<<EOF
 	echo \$this->Form->input('{$field}', array(

--- a/Croogo/Console/Templates/croogo/views/form.ctp
+++ b/Croogo/Console/Templates/croogo/views/form.ctp
@@ -35,10 +35,11 @@ echo "\$this->append('tab-content');\n";
 		if ($field == $primaryKey):
 			continue;
 		elseif (!in_array($field, array('created', 'modified', 'updated'))):
-			$fieldLabel = Inflector::humanize($field);
+			$fieldLabel = chop(chop($field, '_fk'), '_id');
+			$fieldLabel = Inflector::humanize($fieldLabel);
 			echo <<<EOF
 	echo \$this->Form->input('{$field}', array(
-		'label' => '$fieldLabel',
+		'label' =>  __d('$underscoredPluginName', '$fieldLabel'),
 	));\n
 EOF;
 		endif;


### PR DESCRIPTION
1. Chops _id and _fk from fieldname ends
2. Translates field labels onto the domain of the plugin