### PR TITLE
Common/admin_index.ctp buttons translation

### DIFF
--- a/Croogo/View/Common/admin_index.ctp
+++ b/Croogo/View/Common/admin_index.ctp
@@ -36,7 +36,9 @@ endif;
 			echo $actionsBlock;
 		else:
 			echo $this->Croogo->adminAction(
-				__d('croogo', 'New %s', __d('croogo', Inflector::singularize($this->name))),
+				__d('croogo', 'New %s', __d(
+					(empty($this->params['plugin']) ? 'croogo' : $this->params['plugin']),
+					Inflector::humanize(Inflector::underscore($this->name)))),
 				array('action' => 'add'),
 				array('button' => 'success')
 			);


### PR DESCRIPTION
1. set the buttons so that they render the labels (the button text) correctly, so instead of, for example ```New TariffGroupOptionValues``` it renders ```New Tariff Group Option Values```
2. looks up the plugin's dictionary to translate ```Tariff Group Option Values``` if a plugin is specified instead of "croogo"