### PR TITLE
Bugfix and update croogo form bake template

### DIFF
--- a/Croogo/Console/Templates/croogo/views/form.ctp
+++ b/Croogo/Console/Templates/croogo/views/form.ctp
@@ -11,7 +11,7 @@ $header = <<<EOF
 
 if (\$this->action == 'admin_edit') {
 	\$this->Html->addCrumb(\$this->request->data['$modelClass']['$displayField'], '/' . \$this->request->url);
-	\$this->viewVars['title_for_layout'] = '$pluralHumanName: ' . \$this->request->data['$modelClass']['$displayField'];
+	\$this->viewVars['title_for_layout'] = __d('$underscoredPluginName', '$pluralHumanName') . ': ' . \$this->request->data['$modelClass']['$displayField'];
 } else {
 	\$this->Html->addCrumb(__d('croogo', 'Add'), '/' . \$this->request->url);
 }
@@ -29,28 +29,37 @@ echo "\$this->append('tab-heading');\n";
 	echo "\techo \$this->Croogo->adminTabs();\n";
 echo "\$this->end();\n\n";
 
-echo "\$this->append('tab-content');\n";
-	echo "\techo \$this->Form->input('{$primaryKey}');\n";
+echo "\$this->append('tab-content');\n\n";
+
+	echo "\techo \$this->Html->tabStart('{$primaryTab}');\n\n";
+
+	echo "\t\techo \$this->Form->input('{$primaryKey}');\n\n";
+	
 	foreach ($fields as $field):
 		if ($field == $primaryKey):
 			continue;
-		elseif (!in_array($field, array('created', 'modified', 'updated'))):
-			$fieldLabel = Inflector::humanize($field);
+		elseif (!in_array($field, array('created', 'modified', 'updated', 'created_by', 'updated_by'))):
+			$fieldLabel = strrpos($field, '_id', -3) ? substr($field, 0, -3) : $field;
+ 			$fieldLabel = Inflector::humanize($fieldLabel);
 			echo <<<EOF
-	echo \$this->Form->input('{$field}', array(
-		'label' => '$fieldLabel',
-	));\n
+		echo \$this->Form->input('{$field}', array(
+			'label' =>  __d('$underscoredPluginName', '$fieldLabel'),
+		));\n
 EOF;
 		endif;
 	endforeach;
 
 	if (!empty($associations['hasAndBelongsToMany'])):
 		foreach ($associations['hasAndBelongsToMany'] as $assocName => $assocData):
-			echo "\techo \$this->Form->input('{$assocName}');\n";
+			echo "\t\techo \$this->Form->input('{$assocName}');\n";
 		endforeach;
 	endif;
 
-	echo "\techo \$this->Croogo->adminTabs();\n";
+	echo "\n";
+	echo "\techo \$this->Html->tabEnd();\n\n";
+
+	echo "\techo \$this->Croogo->adminTabs();\n\n";
+	
 echo "\$this->end();\n\n";
 
 echo <<<EOF

--- a/Croogo/Console/Templates/croogo/views/form.ctp
+++ b/Croogo/Console/Templates/croogo/views/form.ctp
@@ -1,17 +1,17 @@
 <?php
-$underscoredPluginName = $plugin ? Inflector::underscore($plugin) : 'default';
+$translationDomain = $plugin ? Inflector::underscore($plugin) : 'default';
 $header = <<<EOF
 <?php
-\$this->viewVars['title_for_layout'] = __d('$underscoredPluginName', '$pluralHumanName');
+\$this->viewVars['title_for_layout'] = __d('$translationDomain', '$pluralHumanName');
 \$this->extend('/Common/admin_edit');
 
 \$this->Html
 	->addCrumb('', '/admin', array('icon' => 'home'))
-	->addCrumb(__d('$underscoredPluginName', '${pluralHumanName}'), array('action' => 'index'));
+	->addCrumb(__d('$translationDomain', '${pluralHumanName}'), array('action' => 'index'));
 
 if (\$this->action == 'admin_edit') {
 	\$this->Html->addCrumb(\$this->request->data['$modelClass']['$displayField'], '/' . \$this->request->url);
-	\$this->viewVars['title_for_layout'] = __d('$underscoredPluginName', '$pluralHumanName') . ': ' . \$this->request->data['$modelClass']['$displayField'];
+	\$this->viewVars['title_for_layout'] = __d('$translationDomain', '$pluralHumanName') . ': ' . \$this->request->data['$modelClass']['$displayField'];
 } else {
 	\$this->Html->addCrumb(__d('croogo', 'Add'), '/' . \$this->request->url);
 }
@@ -25,7 +25,7 @@ echo $header;
 $primaryTab = strtolower(Inflector::slug($singularHumanName, '-'));
 
 echo "\$this->append('tab-heading');\n";
-	echo "\techo \$this->Croogo->adminTab(__d('$underscoredPluginName', '$singularHumanName'), '#$primaryTab');\n";
+	echo "\techo \$this->Croogo->adminTab(__d('$translationDomain', '$singularHumanName'), '#$primaryTab');\n";
 	echo "\techo \$this->Croogo->adminTabs();\n";
 echo "\$this->end();\n\n";
 
@@ -43,7 +43,7 @@ echo "\$this->append('tab-content');\n\n";
  			$fieldLabel = Inflector::humanize($fieldLabel);
 			echo <<<EOF
 		echo \$this->Form->input('{$field}', array(
-			'label' =>  __d('$underscoredPluginName', '$fieldLabel'),
+			'label' =>  __d('$translationDomain', '$fieldLabel'),
 		));\n
 EOF;
 		endif;
@@ -67,6 +67,7 @@ echo <<<EOF
 	echo \$this->Html->beginBox(__d('croogo', 'Publishing')) .
 		\$this->Form->button(__d('croogo', 'Apply'), array('name' => 'apply')) .
 		\$this->Form->button(__d('croogo', 'Save'), array('button' => 'primary')) .
+		\$this->Form->button(__d('croogo', 'Save & New'), array('button' => 'primary', 'name' => 'save_and_new')) .
 		\$this->Html->link(__d('croogo', 'Cancel'), array('action' => 'index'), array('button' => 'danger'));
 	echo \$this->Html->endBox();
 


### PR DESCRIPTION
Bug fixes:
* Controller's name in browser's ```<title>``` wasn't translated: Now it is being translated (domain: plugin).
* Hooked admin tabs did not work because of missing ```tabStart()``` for the main tab.
* Labels were not translated: Now they are being translated (domain: plugin).

New features:
* Fields ```created_by``` and ```updated_by``` are being ignored by bake templates now (utilized in ```Croogo.Trackable``` behavior).
* Fieldnames / foreign keys are now treated by removing their conventional ```_id``` if it exists in the fieldname's tail for label output before sending it into the translation function.
* Added some new lines and indentation to make the tab pane's begin and end block more transparent (bake result).

In addition to fixing baked hooked tabs, this includes all changes previously purposed in https://github.com/croogo/croogo/pull/625, https://github.com/croogo/croogo/pull/626 and https://github.com/croogo/croogo/pull/627.