### PR TITLE
Translate the validation messages

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -74,7 +74,7 @@ Wiena Lorentz <lorentz@xintesa.com>
 alevilar <alevilar@gmail.com>
 avra911 <razvan@magnify.ro>
 damarev <damarev@gmail.com>
-elbakai <elbakai@users.noreply.github.com>
+elbakai <m.elbakai@gmail.com>
 eryw <kristeryw@gmail.com>
 ingvaar <igorpletenev@gmail.com>
 joseph-d <joseph.d@nirada.co.th>

--- a/Croogo/Model/CroogoAppModel.php
+++ b/Croogo/Model/CroogoAppModel.php
@@ -29,6 +29,13 @@ class CroogoAppModel extends Model {
 	);
 
 /**
+ * The name of the validation string domain to use when translating validation errors.
+ *
+ * Overwrite the default domain used in translating of model validation errors
+ */
+	public $validationDomain = "croogo";
+
+/**
  * Display fields for admin_index. Use displayFields()
  *
  * @var array

--- a/Extensions/View/ExtensionsPlugins/admin_add.ctp
+++ b/Extensions/View/ExtensionsPlugins/admin_add.ctp
@@ -26,6 +26,7 @@ $this->append('tab-content');
 	echo $this->Html->tabStart('plugin-upload') .
 		$this->Form->input('Plugin.file', array(
 			'type' => 'file',
+			'label' => __d('croogo', 'File'),
 		));
 	echo $this->Html->tabEnd();
 

--- a/Extensions/View/ExtensionsPlugins/admin_add.ctp
+++ b/Extensions/View/ExtensionsPlugins/admin_add.ctp
@@ -34,7 +34,7 @@ $this->append('tab-content');
 $this->end();
 
 $this->append('panels');
-	echo $this->Html->beginBox('Publishing') .
+	echo $this->Html->beginBox(__d('croogo', 'Publishing')) .
 		$this->Form->button(__d('croogo', 'Upload')) .
 		$this->Html->link(__d('croogo', 'Cancel'),
 			array('action' => 'index'),

--- a/Menus/View/Menus/admin_form.ctp
+++ b/Menus/View/Menus/admin_form.ctp
@@ -48,7 +48,7 @@ $this->append('tab-content');
 $this->end();
 
 $this->start('panels');
-	echo $this->Html->beginBox('Publishing') .
+	echo $this->Html->beginBox(__d('croogo', 'Publishing')) .
 		$this->Form->button(__d('croogo', 'Apply'), array('name' => 'apply')) .
 		$this->Form->button(__d('croogo', 'Save'), array('button' => 'success')) .
 		$this->Html->link(__d('croogo', 'Cancel'), array('action' => 'index'), array('button' => 'danger')) .

--- a/Nodes/Controller/NodesController.php
+++ b/Nodes/Controller/NodesController.php
@@ -793,6 +793,9 @@ class NodesController extends NodesAppController {
 		$event = new CakeEvent('Controller.Nodes.view', $this, compact('data'));
 		$this->getEventManager()->dispatch($event);
 
+        	$this->Node->id = $node['Node']['id'];
+        	$this->Node->saveField('visite_count', $node['Node']['visite_count'] + 1);
+        
 		$this->set('title_for_layout', $node[$Node->alias]['title']);
 		$this->set(compact('node', 'type', 'comments'));
 		$this->Croogo->viewFallback(array(

--- a/Nodes/Controller/NodesController.php
+++ b/Nodes/Controller/NodesController.php
@@ -540,7 +540,7 @@ class NodesController extends NodesAppController {
 		$visibilityRolesField = $Node->escapeField('visibility_roles');
 		$this->paginate[$Node->alias]['conditions'] = array(
 			$Node->escapeField('status') => $Node->status(),
-			$Node->escapeField('terms') . ' LIKE' => '%"' . $this->request->params['named']['slug'] . '"%',
+			$Node->escapeField('terms') . ' LIKE' => '%' . $this->request->params['named']['slug'] . '%',
 			'OR' => array(
 				$visibilityRolesField => '',
 				$visibilityRolesField . ' LIKE' => '%"' . $this->Croogo->roleId() . '"%',

--- a/Nodes/Controller/NodesController.php
+++ b/Nodes/Controller/NodesController.php
@@ -253,6 +253,26 @@ class NodesController extends NodesAppController {
 				$typeAlias = $this->request->data[$Node->alias]['type'];
 				$Node->type = $typeAlias;
 			}
+
+			if (Configure::read('Site.post_id_slug') == 1){
+				// Get the last post ID
+				$last_id = $Node->find('first', array(
+						'fields' => array('id'),
+						'order' => array('Node.id' => 'DESC'),
+						'recursive' => '-1',
+					)
+				);
+				
+				// Next id	
+				$next_id = $last_id['Node']['id'] + 1;
+
+				// concat with user ID to prevent duplicate poste ID if two users save post in the same time
+				$post_id = $this->Session->read('Auth.User.id').$next_id;
+
+				// Set the new slug
+				$this->request->data[$Node->alias]['slug'] = $post_id;
+			}// End edited
+			
 			if ($Node->saveNode($this->request->data, $typeAlias)) {
 				Croogo::dispatchEvent('Controller.Nodes.afterAdd', $this, array('data' => $this->request->data));
 				$this->Session->setFlash(__d('croogo', '%s has been saved', $type['Type']['title']), 'flash', array('class' => 'success'));

--- a/Nodes/View/Nodes/admin_form.ctp
+++ b/Nodes/View/Nodes/admin_form.ctp
@@ -56,6 +56,11 @@ $this->append('tab-heading');
 	echo $this->Croogo->adminTabs();
 $this->end();
 
+if (Configure::read('Site.post_id_slug') == 1){
+	$slug_type = 'hidden';
+}else{
+	$slug_type = 'text';
+}
 $this->append('tab-content');
 
 	echo $this->Html->tabStart('node-main') .
@@ -77,6 +82,7 @@ $this->append('tab-content');
 		)) .
 		$this->Form->input('slug', array(
 			'class' => trim($inputClass . ' slug'),
+			'type' => $slug_type,
 			'label' => __d('croogo', 'Slug'),
 		)) .
 		$this->Form->input('excerpt', array(

--- a/Users/View/Users/login.ctp
+++ b/Users/View/Users/login.ctp
@@ -3,9 +3,9 @@
 	<?php echo $this->Form->create('User', array('url' => array('controller' => 'users', 'action' => 'login')));?>
 		<fieldset>
 		<?php
-			echo $this->Form->input('username');
-			echo $this->Form->input('password');
+			echo $this->Form->input('username', array('label' => __d('croogo', 'Username')));
+			echo $this->Form->input('password', array('label' => __d('croogo', 'Password')));
 		?>
 		</fieldset>
-	<?php echo $this->Form->end('Submit');?>
+	<?php echo $this->Form->end(__d('croogo', 'Submit'));?>
 </div>


### PR DESCRIPTION
Probleme: the messages of validation in the model are not translated
Cause: The name of the validation string domain used when translating validation errors is not defined
Solution: Overwrite the default domain used in translating of model validation errors