### PR TITLE
Fixed typeahead overzealously resetting hidden field

### DIFF
--- a/Croogo/webroot/js/typeahead_autocomplete.js
+++ b/Croogo/webroot/js/typeahead_autocomplete.js
@@ -53,14 +53,24 @@
 			var map = {};
 			var $rel = $(options.relatedElement);
 			var $element = $(plugin.element);
+			var originalValues;
 
 			$element
-				.on('focus', function(e) {
-					$rel.val('');
+				.on('focus', function() {
+					originalValues = {
+						rel: $rel.val(),
+						el: this.value
+					};
 				})
 				.on('blur', function(e) {
+					if (this.value.length == 0) {
+						$rel.val('');
+					}
 					if ($rel.val().length == 0) {
 						this.value = '';
+					}
+					if (originalValues.rel === $rel.val()) {
+						this.value = originalValues.el;
 					}
 				});
 			$element.typeahead({


### PR DESCRIPTION
Typeahead was basically broken in 26d043d11fe6bab5c32a71d0ccccf4f87a3059b3 and was overwriting the hidden field all the time. This fix retains the original commit's goals.