### PR TITLE
Fix: Escape flash message in acl_actions/admin_generate

### DIFF
--- a/Acl/Controller/AclActionsController.php
+++ b/Acl/Controller/AclActionsController.php
@@ -176,7 +176,7 @@ class AclActionsController extends AclAppController {
 			$class = 'error';
 		}
 
-		$this->Session->setFlash(join('<br>', $output), 'flash', array('class' => $class));
+		$this->Session->setFlash(join('<br>', $output), 'flash', array('class' => $class, 'escape' => false));
 
 		if (isset($this->request->params['named']['permissions'])) {
 			return $this->redirect(array('plugin' => 'acl', 'controller' => 'acl_permissions', 'action' => 'index'));

--- a/Croogo/Test/Case/AllCroogoTestsTest.php
+++ b/Croogo/Test/Case/AllCroogoTestsTest.php
@@ -1,6 +1,8 @@
 <?php
 App::uses('CroogoTestCase', 'Croogo.TestSuite');
 
+ini_set('error_reporting', ini_get('error_reporting') & ~E_USER_DEPRECATED);
+
 class AllCroogoTestsTest extends PHPUnit_Framework_TestSuite {
 
 /**


### PR DESCRIPTION
Without `escape = false`, the `<warning>` gets escaped and visible in the flash message.