### PR TITLE
Use Croogo's Users table for authentication

### DIFF
--- a/Acl/src/Controller/Component/FilterComponent.php
+++ b/Acl/src/Controller/Component/FilterComponent.php
@@ -76,11 +76,15 @@ class FilterComponent extends Component {
 		//Configure AuthComponent
 		$this->_controller->Auth->authenticate = array(
 			AuthComponent::ALL => array(
-				'userModel' => 'Users.User',
+				'userModel' => 'Croogo/Users.Users',
 				'fields' => array(
 					'username' => 'username',
 					'password' => 'password',
 				),
+				'passwordHasher' => [
+					'className' => 'Fallback',
+					'hashers' => ['Default', 'Weak']
+				],
 				'scope' => array(
 					'User.status' => 1,
 				),

--- a/Core/src/Controller/CroogoAppController.php
+++ b/Core/src/Controller/CroogoAppController.php
@@ -48,7 +48,8 @@ class CroogoAppController extends AppController {
 					'passwordHasher' => [
 						'className' => 'Fallback',
 						'hashers' => ['Default', 'Weak']
-					]
+					],
+					'userModel' => 'Croogo/Users.Users'
 				]
 			]
 		],

--- a/Core/src/Controller/CroogoAppController.php
+++ b/Core/src/Controller/CroogoAppController.php
@@ -42,17 +42,7 @@ class CroogoAppController extends AppController {
 		'Croogo/Acl.Filter',
 		'Security',
 		'Acl.Acl',
-		'Auth' => [
-			'authenticate' => [
-				'Form' => [
-					'passwordHasher' => [
-						'className' => 'Fallback',
-						'hashers' => ['Default', 'Weak']
-					],
-					'userModel' => 'Croogo/Users.Users'
-				]
-			]
-		],
+		'Auth',
 		'Flash',
 		'RequestHandler',
 	);


### PR DESCRIPTION
Currently no table is used for the Cake's Auth Component (e.g. `$this->Auth->identify();`). Now I default this to Croogo's Users table.