### PR TITLE
Error on switch language on multiple locale site

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+sudo: false
+
 php:
   - 5.3
   - 5.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 5.3
   - 5.4
+  - 5.5
 
 env:
   - DB=mysql
@@ -25,8 +26,7 @@ before_install:
   - sh -c "if [ '$TRAVIS_PHP_VERSION' = '5.2' ] ; then git clone --depth 1 git://github.com/croogo/Ckeditor -b master app/Plugin/Ckeditor ; fi"
   - sh -c "if [ '$TRAVIS_PHP_VERSION' != '5.2' ]; then composer global require 'phpunit/phpunit=3.7.33'; fi"
   - sh -c "if [ '$TRAVIS_PHP_VERSION' != '5.2' ]; then ln -s ~/.composer/vendor/phpunit/phpunit/PHPUnit app/Vendor/PHPUnit; fi"
-  - sh -c "if [ '$TRAVIS_PHP_VERSION' = '5.3' ] ; then composer -n -vv install ; fi"
-  - sh -c "if [ '$TRAVIS_PHP_VERSION' = '5.4' ] ; then composer -n -vv install ; fi"
+  - sh -c "if [ '$TRAVIS_PHP_VERSION' != '5.2' ] ; then composer -n -vv install ; fi"
   - for d in Plugin/* ; do if [ ! -f $app/$d ] ; then ln -s `pwd`/$d app/$d; fi ; done
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ before_script:
   - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'CREATE SCHEMA croogo_test;' -U postgres -d croogo_test; fi"
   - cp app/Config/settings.json.install app/Config/settings.json
   - cp app/Config/croogo.php.install app/Config/croogo.php
+  - sed -i "s/E_DEPRECATED,$/E_DEPRECATED \& ~E_USER_DEPRECATED,/" app/Config/croogo.php
   - set +H
   - echo "<?php
     class DATABASE_CONFIG {

--- a/Croogo/View/Elements/admin/search.ctp
+++ b/Croogo/View/Elements/admin/search.ctp
@@ -7,7 +7,7 @@ if (!isset($className)) {
 }
 if (!empty($searchFields)):
 ?>
-<div class="<?php echo $className; ?> filter">
+<div class="<?php echo $className; ?> clearfix filter">
 <?php
 	echo $this->Form->create($modelClass, array(
 		'class' => 'form-inline',


### PR DESCRIPTION
I have a website with a multiple languages (eng, fra, ara), sometimes when i click on the link to switch for example from **ara** to **eng**, it dose not work !!! the website redirect to the source language and the current language become **img** - when i check `Configure::read('Config.language')` it show **img** . it work in some pages and not on others, after trying and checking, i found that the problem is caused by **broken images**, and it's not work just in the pages having a broken images, because broken images give errors like 

```
2015-11-12 00:28:37 Error: [MissingControllerException] Controller class ClientsController could not be found.
Exception Attributes: array (
  'class' => 'ClientsController',
  'plugin' => NULL,
)
Request URL: /laboratory/img/clients/centre-city.jpg
```

and it take the **img** as a language's alias, that is why when i check `Configure::read('Config.language')` it contain **img**

 also when i check **beforeFilter** at **Croogo/Croogo/Controller/CroogoAppController**, i found that `Configure::read('Config.language')` take **img** as a langague's alias, it can access even there is no locale on the url.

```
        if (isset($this->request->params['locale'])) {
            Configure::write('Config.language', $this->request->params['locale']);
        }
```
### Solution

So that is why we should check if the current language was defined by the user or not, 

```
        // we should add Configure::write('localeLanguages', array('fra', 'eng', 'ara')); on Config/croogo.php
        if (isset($this->request->params['locale']) && in_array($this->request->params['locale'], Configure::read('localeLanguages')))
        {
            Configure::write('Config.language', $this->request->params['locale']);
        }
```

and it work fine like that.
