### PR TITLE
Expose CroogoStatus::statuses() $type var

### DIFF
--- a/Croogo/View/Helper/CroogoHelper.php
+++ b/Croogo/View/Helper/CroogoHelper.php
@@ -56,8 +56,8 @@ class CroogoHelper extends AppHelper {
 		}
 	}
 
-	public function statuses() {
-		return $this->_CroogoStatus->statuses();
+	public function statuses($type = 'publishing') {
+		return $this->_CroogoStatus->statuses($type);
 	}
 
 /**


### PR DESCRIPTION
Helper function only ever returned the default 'publishing' statuses.  

Exposing the CroogoStatus::statuses() $type variable to the CroogoHelper solves this allows you to now request 'approval' or any 'custom' statuses.
