### PR TITLE
added possibility to change sub-tag in menus and add class on it

### DIFF
--- a/Menus/src/View/Helper/MenusHelper.php
+++ b/Menus/src/View/Helper/MenusHelper.php
@@ -132,6 +132,8 @@ class MenusHelper extends Helper {
 		$_options = array(
 			'tag' => 'ul',
 			'tagAttributes' => array(),
+			'subTag' => 'li',
+			'subTagAttributes' => array(),
 			'selected' => 'selected',
 			'dropdown' => false,
 			'dropdownClass' => 'sf-menu',
@@ -219,7 +221,8 @@ class MenusHelper extends Helper {
 				$linkOutput .= $this->nestedLinks($link['children'], $options, $depth + 1);
 			}
 			$liAttr = $this->_mergeLinkParams($link, 'liAttr');
-			$linkOutput = $this->Html->tag('li', $linkOutput, $liAttr);
+			$liAttr = !empty($liAttr) ? $liAttr : $options['subTagAttributes'];
+			$linkOutput = $this->Html->tag($options['subTag'], $linkOutput, $liAttr);
 			$output .= $linkOutput;
 		}
 		if ($output != null) {


### PR DESCRIPTION
Menus:
Now it is possible to change the sub-tag (li-tag) according to the main tag via new option "subTag" analog to "tag" and customize it via "subTagAttributes" option, according to main-tag's "tagAttributes". Enabled styling of custom menus.