### PR TITLE
Updated notEmpty to notBlank validation rule

### DIFF
--- a/Comments/Model/Comment.php
+++ b/Comments/Model/Comment.php
@@ -60,11 +60,11 @@ class Comment extends AppModel {
  */
 	public $validate = array(
 		'body' => array(
-			'rule' => 'notEmpty',
+			'rule' => 'notBlank',
 			'message' => 'This field cannot be left blank.',
 		),
 		'name' => array(
-			'rule' => 'notEmpty',
+			'rule' => 'notBlank',
 			'message' => 'This field cannot be left blank.',
 		),
 		'email' => array(

--- a/Contacts/Model/Contact.php
+++ b/Contacts/Model/Contact.php
@@ -45,7 +45,7 @@ class Contact extends ContactsAppModel {
  */
 	public $validate = array(
 		'title' => array(
-			'rule' => 'notEmpty',
+			'rule' => 'notBlank',
 			'message' => 'This field cannot be left blank.',
 		),
 		'alias' => array(

--- a/Contacts/Model/Message.php
+++ b/Contacts/Model/Message.php
@@ -47,7 +47,7 @@ class Message extends ContactsAppModel {
  */
 	public $validate = array(
 		'name' => array(
-			'rule' => 'notEmpty',
+			'rule' => 'notBlank',
 			'message' => 'This field cannot be left blank.',
 		),
 		'email' => array(
@@ -55,11 +55,11 @@ class Message extends ContactsAppModel {
 			'message' => 'Please provide a valid email address.',
 		),
 		'title' => array(
-			'rule' => 'notEmpty',
+			'rule' => 'notBlank',
 			'message' => 'This field cannot be left blank.',
 		),
 		'body' => array(
-			'rule' => 'notEmpty',
+			'rule' => 'notBlank',
 			'message' => 'This field cannot be left blank.',
 		),
 	);

--- a/Nodes/Model/Node.php
+++ b/Nodes/Model/Node.php
@@ -118,7 +118,7 @@ class Node extends NodesAppModel {
  */
 	public $validate = array(
 		'title' => array(
-			'rule' => 'notEmpty',
+			'rule' => 'notBlank',
 			'message' => 'This field cannot be left blank.',
 		),
 		'slug' => array(

--- a/Users/Model/Role.php
+++ b/Users/Model/Role.php
@@ -45,7 +45,7 @@ class Role extends UsersAppModel {
 	public $validate = array(
 		'title' => array(
 			'notEmpty' => array(
-				'rule' => 'notEmpty',
+				'rule' => 'notBlank',
 				'message' => 'Alias cannot be empty.',
 				'last' => true,
 			),
@@ -62,7 +62,7 @@ class Role extends UsersAppModel {
 				'last' => true,
 			),
 			'notEmpty' => array(
-				'rule' => 'notEmpty',
+				'rule' => 'notBlank',
 				'message' => 'Alias cannot be empty.',
 				'last' => true,
 			),

--- a/Users/Model/User.php
+++ b/Users/Model/User.php
@@ -60,7 +60,7 @@ class User extends UsersAppModel {
 				'last' => true,
 			),
 			'notEmpty' => array(
-				'rule' => 'notEmpty',
+				'rule' => 'notBlank',
 				'message' => 'This field cannot be left blank.',
 				'last' => true,
 			),
@@ -91,7 +91,7 @@ class User extends UsersAppModel {
 		),
 		'name' => array(
 			'notEmpty' => array(
-				'rule' => 'notEmpty',
+				'rule' => 'notBlank',
 				'message' => 'This field cannot be left blank.',
 				'last' => true,
 			),


### PR DESCRIPTION
This fixes many deprecated messages when using the latest version of Cake2.