### PR TITLE
Fix: broken view path searching

### DIFF
--- a/Croogo/Controller/CroogoAppController.php
+++ b/Croogo/Controller/CroogoAppController.php
@@ -398,14 +398,14 @@ class CroogoAppController extends Controller {
 			$file = $this->viewPath . DS . $this->request->action . '.ctp';
 			$requested = $path . $file;
 			if (file_exists($requested)) {
-				return $requested;
+				return $this->request->action;
 			} else {
 				if (!$this->plugin) {
 					continue;
 				}
 				$requested = $path . 'Plugin' . DS . $this->plugin . DS . $file;
 				if (file_exists($requested)) {
-					return $requested;
+					return $this->request->action;
 				}
 			}
 		}


### PR DESCRIPTION
This is due to cakephp/cakephp@5e60cc5d182e6131e3fbdfdf69f49d560c9ff78b

The broken functionality is in `/admin/file_manager/attachments/add`