### PR TITLE
Change link separator back to / since values should be urlencoded

### DIFF
--- a/Core/src/Link.php
+++ b/Core/src/Link.php
@@ -26,7 +26,10 @@ class Link extends ArrayObject
 
     public function getUrl()
     {
-        return (isset($this->controller)) ? $this->getArrayCopy() : $this->url;
+        $copy = array_map(function($val) {
+            return urldecode($val);
+        }, $this->getArrayCopy());
+        return (isset($this->controller)) ? $copy : $this->url;
     }
 
     public function toLinkString()

--- a/Core/src/Utility/StringConverter.php
+++ b/Core/src/Utility/StringConverter.php
@@ -122,7 +122,7 @@ class StringConverter
             parse_str(substr($link, $pos + 1), $query);
             $link = substr($link, 0, $pos);
         }
-        $link = explode('|', $link);
+        $link = explode('/', $link);
         $linkArr = [];
         foreach ($link as $linkElement) {
             if ($linkElement != null) {
@@ -131,7 +131,7 @@ class StringConverter
                     if (in_array($linkElementE['1'], ['true', 'false'])) {
                         $linkArr[$linkElementE['0']] = ($linkElementE['0'] === 'true') ? true : false;
                     } else {
-                        $linkArr[$linkElementE['0']] = urldecode($linkElementE['1']);
+                        $linkArr[$linkElementE['0']] = $linkElementE['1'];
                     }
                 } else {
                     $linkArr[] = $linkElement;
@@ -182,7 +182,7 @@ class StringConverter
                 $result[] = $val;
             }
         }
-        return join('|', $result) . $queryString;
+        return join('/', $result) . $queryString;
     }
 
 /**

--- a/Menus/src/View/Helper/MenusHelper.php
+++ b/Menus/src/View/Helper/MenusHelper.php
@@ -217,7 +217,7 @@ class MenusHelper extends Helper
                 $currentUrl = $this->_View->request->url;
             }
 
-            if (Router::url($link->link->getArrayCopy()) == Router::url('/' . $currentUrl)) {
+            if (Router::url($link->link->getUrl()) == Router::url('/' . $currentUrl)) {
                 if (!isset($linkAttr['class'])) {
                     $linkAttr['class'] = '';
                 }


### PR DESCRIPTION
This is a partial revert of ff8bf4ddc5f2c3c08a8dc6f714a1351d242a380a

Using `/` in this case feels more natural.  So instead of changing our separator to `|`, values containing the `/` character must be urlencoded instead. Eg: `plugin:Croogo%2FNodes/controller:Nodes/action:promoted`.