### PR TITLE
Add ability to set paginate->order from params

### DIFF
--- a/Nodes/Controller/NodesController.php
+++ b/Nodes/Controller/NodesController.php
@@ -470,6 +470,9 @@ class NodesController extends NodesAppController {
 			if (isset($type['Params']['nodes_per_page']) && empty($this->request->params['named']['limit'])) {
 				$limit = $type['Params']['nodes_per_page'];
 			}
+			if (isset($type['Params']['order']) && empty($this->request->params['named']['order'])) {
+				$this->paginate[$Node->alias]['order'] = $type['Params']['order'];
+			}
 			$this->paginate[$Node->alias]['conditions']['Node.type'] = $type['Type']['alias'];
 			$this->set('title_for_layout', $type['Type']['title']);
 		}


### PR DESCRIPTION
Makes sense that if you can set default paginate->limit value from params (using nodes_per_page) you should also be able to set the default paginate->order value.  May want to change the name of the params variable used to sort_order or something more specific to its use case.
