### PR TITLE
Improve _findByVocabulary

### DIFF
--- a/Taxonomy/Model/Term.php
+++ b/Taxonomy/Model/Term.php
@@ -235,7 +235,7 @@ class Term extends TaxonomyAppModel {
 			trigger_error(__d('croogo', '"vocabulary_id" key not found'));
 		}
 		if ($state == 'before') {
-			$vocabularyAlias = $this->Vocabulary->field('alias', array('id' => $query['vocabulary_id']));
+			$vocabularyAlias = $this->Vocabulary->field('alias', array($this->alias . '.id' => $query['vocabulary_id']));
 			$termsId = $this->Vocabulary->Taxonomy->getTree($vocabularyAlias, array('key' => 'id', 'value' => 'title'));
 			$defaultQuery = array(
 				'conditions' => array(

--- a/Taxonomy/Model/Term.php
+++ b/Taxonomy/Model/Term.php
@@ -235,7 +235,7 @@ class Term extends TaxonomyAppModel {
 			trigger_error(__d('croogo', '"vocabulary_id" key not found'));
 		}
 		if ($state == 'before') {
-			$vocabularyAlias = $this->Vocabulary->field('alias', array($this->alias . '.id' => $query['vocabulary_id']));
+			$vocabularyAlias = $this->Vocabulary->field('alias', array('Vocabulary.id' => $query['vocabulary_id']));
 			$termsId = $this->Vocabulary->Taxonomy->getTree($vocabularyAlias, array('key' => 'id', 'value' => 'title'));
 			$defaultQuery = array(
 				'conditions' => array(


### PR DESCRIPTION
Use explicit Model.id for condition within Model::field() call to avoid issues when extending model data
