### PR TITLE
Avoid registering non-action public methods to acl

### DIFF
--- a/Blocks/src/Controller/Admin/BlocksController.php
+++ b/Blocks/src/Controller/Admin/BlocksController.php
@@ -29,7 +29,7 @@ class BlocksController extends AppController
         parent::initialize();
         $this->loadModel('Croogo/Users.Roles');
 
-        $this->loadCroogoComponents(['BulkProcess']);
+        $this->_loadCroogoComponents(['BulkProcess']);
         $this->_setupPrg();
 
         $this->Crud->config('actions.index', [

--- a/Comments/src/Controller/Admin/CommentsController.php
+++ b/Comments/src/Controller/Admin/CommentsController.php
@@ -22,7 +22,7 @@ class CommentsController extends AppController
     {
         parent::initialize();
 
-        $this->loadCroogoComponents(['Akismet', 'BulkProcess', 'Recaptcha']);
+        $this->_loadCroogoComponents(['Akismet', 'BulkProcess', 'Recaptcha']);
     }
 
     /**

--- a/Comments/src/Controller/CommentsController.php
+++ b/Comments/src/Controller/CommentsController.php
@@ -33,7 +33,7 @@ class CommentsController extends AppController
     {
         parent::initialize();
 
-        $this->loadCroogoComponents(['Akismet', 'BulkProcess', 'Recaptcha' => [
+        $this->_loadCroogoComponents(['Akismet', 'BulkProcess', 'Recaptcha' => [
             'actions' => ['add']
         ]]);
         $this->_setupPrg();

--- a/Contacts/src/Controller/Admin/MessagesController.php
+++ b/Contacts/src/Controller/Admin/MessagesController.php
@@ -22,7 +22,7 @@ class MessagesController extends AppController
 
         $this->_setupPrg();
 
-        $this->loadCroogoComponents(['BulkProcess']);
+        $this->_loadCroogoComponents(['BulkProcess']);
     }
 
 /**

--- a/Core/src/Controller/AppController.php
+++ b/Core/src/Controller/AppController.php
@@ -79,7 +79,7 @@ class AppController extends \App\Controller\AppController implements HookableCom
 
     public function initialize()
     {
-        $this->dispatchBeforeInitialize();
+        $this->_dispatchBeforeInitialize();
 
         parent::initialize();
     }
@@ -159,7 +159,7 @@ class AppController extends \App\Controller\AppController implements HookableCom
         $this->{$aclFilterComponent}->auth();
 
         if (!$this->request->is('api')) {
-            $this->Security->blackHoleCallback = 'securityError';
+            $this->Security->blackHoleCallback = '_securityError';
             if ($this->request->param('action') == 'delete' && $this->request->param('prefix') == 'admin') {
                 $this->request->allowMethod('post');
             }
@@ -179,7 +179,7 @@ class AppController extends \App\Controller\AppController implements HookableCom
      *
      * @return void
      */
-    public function securityError($type)
+    public function _securityError($type)
     {
         switch ($type) {
             case 'auth':
@@ -226,7 +226,7 @@ class AppController extends \App\Controller\AppController implements HookableCom
         ]);
     }
 
-    public function loadCroogoComponents(array $components)
+    public function _loadCroogoComponents(array $components)
     {
         foreach ($components as $component => $options) {
             if (is_string($options)) {

--- a/Core/src/Controller/ErrorController.php
+++ b/Core/src/Controller/ErrorController.php
@@ -44,7 +44,7 @@ class ErrorController extends \Cake\Controller\ErrorController implements Hookab
 
     public function initialize()
     {
-        $this->dispatchBeforeInitialize();
+        $this->_dispatchBeforeInitialize();
 
         if (count(Router::extensions()) && !isset($this->RequestHandler)) {
             $this->loadComponent('RequestHandler');

--- a/Core/src/Controller/HookableComponentInterface.php
+++ b/Core/src/Controller/HookableComponentInterface.php
@@ -5,5 +5,5 @@ namespace Croogo\Core\Controller;
 interface HookableComponentInterface
 {
 
-    public function loadHookableComponent($name, array $config);
+    public function _loadHookableComponent($name, array $config);
 }

--- a/Core/src/Controller/HookableComponentTrait.php
+++ b/Core/src/Controller/HookableComponentTrait.php
@@ -7,12 +7,12 @@ use Cake\Event\Event;
 trait HookableComponentTrait
 {
 
-    public function dispatchBeforeInitialize()
+    public function _dispatchBeforeInitialize()
     {
         $this->eventManager()->dispatch(new Event('Controller.beforeInitialize', $this));
     }
 
-    public function loadHookableComponent($name, array $config)
+    public function _loadHookableComponent($name, array $config)
     {
         return $this->loadComponent($name, $config);
     }

--- a/Extensions/src/Event/HookableComponentEventHandler.php
+++ b/Extensions/src/Event/HookableComponentEventHandler.php
@@ -35,7 +35,7 @@ class HookableComponentEventHandler implements EventListenerInterface
 
         $components = $this->_getComponents($controller);
         foreach ($components as $component => $config) {
-            $controller->loadHookableComponent($component, $config);
+            $controller->_loadHookableComponent($component, $config);
         }
     }
 


### PR DESCRIPTION
I'm open if anyone has better ideas.