### PR TITLE
Remove assignment of new by reference

### DIFF
--- a/Extensions/Controller/ExtensionsLocalesController.php
+++ b/Extensions/Controller/ExtensionsLocalesController.php
@@ -44,7 +44,7 @@ class ExtensionsLocalesController extends ExtensionsAppController {
 		$this->set('title_for_layout', __d('croogo', 'Locales'));
 
 		$locales = array();
-		$folder =& new Folder;
+		$folder = new Folder;
 		$paths = App::path('Locale');
 		foreach ($paths as $path) {
 			$folder->path = $path;
@@ -184,7 +184,7 @@ class ExtensionsLocalesController extends ExtensionsAppController {
 			return $this->redirect(array('action' => 'index'));
 		}
 
-		$file =& new File($poFile, true);
+		$file = new File($poFile, true);
 		$content = $file->read();
 
 		if (!empty($this->request->data)) {
@@ -212,7 +212,7 @@ class ExtensionsLocalesController extends ExtensionsAppController {
 			return $this->redirect(array('action' => 'index'));
 		}
 
-		$file =& new File($poFile, true);
+		$file = new File($poFile, true);
 		if ($file->delete()) {
 			$this->Session->setFlash(__d('croogo', 'Locale deleted successfully.'), 'flash', array('class' => 'success'));
 		} else {

--- a/Install/Lib/InstallManager.php
+++ b/Install/Lib/InstallManager.php
@@ -71,7 +71,7 @@ class InstallManager {
 			return $msg;
 		}
 
-		$File =& new File($croogoConfigFile);
+		$File = new File($croogoConfigFile);
 		$salt = Security::generateAuthKey();
 		$seed = mt_rand() . mt_rand();
 		$contents = $File->read();

--- a/Menus/View/Helper/MenusHelper.php
+++ b/Menus/View/Helper/MenusHelper.php
@@ -163,7 +163,7 @@ class MenusHelper extends AppHelper {
 				unset($options[$key]);
 			}
 			if (is_string($val) && in_array(strtolower($val), $booleans)) {
-				$options[$key] = (bool)$val;
+				$options[$key] = (strtolower($val)==='true');
 			}
 		}
 


### PR DESCRIPTION
Compatibility with PHP7
[New objects cannot be assigned by reference.](http://php.net/manual/en/migration70.incompatible.php#migration70.incompatible.other)
Resolves #785 