### PR TITLE
Eliminate "doesn't have a default value" sql error on install.

### DIFF
--- a/Install/Config/Data/SettingData.php
+++ b/Install/Config/Data/SettingData.php
@@ -319,6 +319,7 @@ options={"Nodes.Node": "Node", "Blocks.Block": "Block", "Menus.Menu": "Menu", "M
 			'key' => 'Access Control.splitSession',
 			'value' => '',
 			'title' => 'Separate front-end and admin session',
+			'description' => '',
 			'input_type' => 'checkbox',
 			'editable' => '1',
 			'weight' => '27',


### PR DESCRIPTION
When installing on a database with sql_mode variable containing STRICT_TRANS_TABLES option (probably others as well), the splitSession setting generated the error below. OS X El Capitan came with this setting included by default, first time I've seen it on the Macs.

SQLSTATE[HY000]: General error: 1364 Field 'description' doesn't have a default value
