### PR TITLE
setTreeScope before edit save

### DIFF
--- a/Menus/Controller/LinksController.php
+++ b/Menus/Controller/LinksController.php
@@ -184,6 +184,7 @@ class LinksController extends MenusAppController {
 		if (!empty($this->request->data)) {
 			$this->request->data['Link']['visibility_roles'] = $this->Link->encodeData($this->request->data['Role']['Role']);
 
+			$this->Link->setTreeScope($this->request->data['Link']['menu_id']);
 			if ($this->Link->save($this->request->data)) {
 				$this->Session->setFlash(__d('croogo', 'The Link has been saved'), 'flash', array('class' => 'success'));
 				if (isset($this->request->data['apply'])) {


### PR DESCRIPTION
Looks like d5a61ca removed this line inadvertently while making some other changes. Without setting the tree scope before performing the save, a parent change can cause "out of scope" changes as well.

Specifically, lets say we have two menus, one with 2 links, another with 3;

```
Link
    id=1, menu_id=1, lft=1, rght=4
    id=2, menu_id=1, lft=2, rght=3
    id=3, menu_id=2, lft=1, rght=6
    id=4, menu_id=2, lft=2, rght=3
    id=5, menu_id=2, lft=4, rght=5

(structure)
    link1 (in menu 1)
        link2
    link3 (in menu 2)
        link4
        link5
```

Notice that both of these menus have the same general structure, and hence some of the links have the same lft/rght values. That's normal. Next, lets try to re-parent link2 using the standard edit form and the dropdown box, for example, we want to make link2 a sibling of link1 rather than a child. Without setting the tree scope before the save, the query does not contain the "menu_id=1" condition. Without that condition the save now matches any link where "lft=2 and rght=3" and moves both link2 and link4. And notice the horked up lft/rght in menu1, it bases the new values on the max from all the menus, not just the one you're modifying. You end up with something that looks kind-of like this;

```
Link
    id=1, menu_id=1, lft=1, rght=2
    id=2, menu_id=1, lft=5, rght=6 <-- notice it skips 3,4
    id=3, menu_id=2, lft=1, rght=4
    id=5, menu_id=2, lft=2, rght=3
    id=4, menu_id=2, lft=5, rght=6 <-- obviously shouldn't have moved this at all

(structure)
    link1 (in menu 1)
    link2
    link3 (in menu 2)
        link5
    link4
```

Later on, when you try to moveup/down some of the links, because of the skips, it seems the tree algorithm doesn't recover and starts to assume parent/child relationships where they don't exist. At that point, everything goes wonky, and its impossible to recover from the admin interface. It requires hand editing of the database to fix.

I did not create test cases for this mostly due to lack of time, but also since the existing tests didn't contain anything with respect to the scope setting. I felt this was a pretty critical fix, and pretty well understood even w/o the test cases, so am submitting it anyway for your consideration.
