### PR TITLE
Use the Hash class to get the prefix

### DIFF
--- a/Core/config/croogo_bootstrap.php
+++ b/Core/config/croogo_bootstrap.php
@@ -44,7 +44,7 @@ EventManager::instance();
      * Cache configuration
      */
     $defaultEngine = Cache::config('default')['className'];
-    $defaultPrefix = Cache::config('default')['prefix'];
+    $defaultPrefix = Hash::get(Cache::config('default'), 'prefix', 'cake_');
     $cacheConfig = [
         'duration' => '+1 hour',
         'path' => CACHE . 'queries' . DS,


### PR DESCRIPTION
By default, applications do not have a prefix set, and engines will inject their own. We default to `cake_`, as is specified in most engines.

This probably will fix two undefined index errors during test runs.