### PR TITLE
Added core plugins to settings seed

### DIFF
--- a/Example/config/plugin.json
+++ b/Example/config/plugin.json
@@ -9,7 +9,7 @@
 	"dependencies": {
 		"plugins": [
 			"acl",
-			"extensions"
+			"Croogo/Extensions"
 		]
 	}
 }

--- a/Settings/config/Seeds/SettingsSeed.php
+++ b/Settings/config/Seeds/SettingsSeed.php
@@ -251,7 +251,7 @@ class SettingsSeed extends AbstractSeed
         [
             'id' => '32',
             'key' => 'Hook.bootstraps',
-            'value' => 'Croogo/Settings,Croogo/Contacts,Croogo/Nodes,Croogo/Meta,Croogo/Menus,Croogo/Users,Croogo/Blocks,Croogo/Taxonomy,Croogo/FileManager,Croogo/Wysiwyg,Croogo/Dashboards',
+            'value' => 'Croogo/Acl,Croogo/Extensions,Croogo/Settings,Croogo/Contacts,Croogo/Nodes,Croogo/Meta,Croogo/Menus,Croogo/Users,Croogo/Blocks,Croogo/Taxonomy,Croogo/FileManager,Croogo/Wysiwyg,Croogo/Dashboards',
             'title' => '',
             'description' => '',
             'input_type' => '',


### PR DESCRIPTION
I was playing around with Croogo 3.x for a little and tried to install my own extension. Since the .zip upload seems kind of broken I just put it in the plugin folder. It then showed up on the plugins list, but I couldn't activate it because somehow Croogo was convinced that Croogo/Extensions (and Croogo/Acl for that matter) were not activated. However there was no option to activate them, so I guess they should be activated by default which makes this the right place to put them, I hope :)