### PR TITLE
Fixed pluginPath in plugin delete method. Fixes #819

### DIFF
--- a/Core/src/Plugin.php
+++ b/Core/src/Plugin.php
@@ -915,7 +915,7 @@ class Plugin extends CakePlugin
         if (empty($plugin)) {
             throw new InvalidArgumentException(__d('croogo', 'Invalid plugin'));
         }
-        $pluginPath = APP . 'Plugin' . DS . $plugin;
+        $pluginPath = ROOT . DS . 'plugins' . DS . $plugin;
         if (is_link($pluginPath)) {
             return unlink($pluginPath);
         }


### PR DESCRIPTION
Fixed the path in Croogo's `Plugin::delete()` method. Files are now properly deleted. 