### PR TITLE
3.0 breadcrumbs

### DIFF
--- a/Acl/src/Template/Admin/Actions/form.ctp
+++ b/Acl/src/Template/Admin/Actions/form.ctp
@@ -7,11 +7,11 @@ $this->Breadcrumbs
     ->add(__d('croogo', 'Actions'), array('plugin' => 'Croogo/Acl', 'controller' => 'Actions', 'action' => 'index'));
 
 if ($this->request->param('action') == 'edit') {
-    $this->Breadcrumbs->add($aco->id . ': ' . $aco->alias, $this->request->here());
+    $this->Breadcrumbs->add($aco->id . ': ' . $aco->alias, $this->request->getRequestTarget());
 }
 
 if ($this->request->param('action') == 'add') {
-    $this->Breadcrumbs->add(__d('croogo', 'Add'), $this->request->here());
+    $this->Breadcrumbs->add(__d('croogo', 'Add'), $this->request->getRequestTarget());
 }
 
 $this->assign('form-start', $this->Form->create($aco));
@@ -27,7 +27,6 @@ $this->append('tab-content');
         'options' => $acos,
         'empty' => true,
         'label' => __d('croogo', 'Parent'),
-        'help' => __d('croogo', 'Choose none if the Aco is a controller.'),
     ));
     $this->Form->templates(array(
         'class' => 'span10',

--- a/Acl/src/Template/Admin/Permissions/index.ctp
+++ b/Acl/src/Template/Admin/Permissions/index.ctp
@@ -8,7 +8,7 @@ $this->Croogo->adminScript('Croogo/Acl.acl_permissions');
 
 $this->Breadcrumbs->add(__d('croogo', 'Users'),
         ['plugin' => 'Croogo/Users', 'controller' => 'Users', 'action' => 'index'])
-    ->add(__d('croogo', 'Permissions'), $this->request->url);
+    ->add(__d('croogo', 'Permissions'), $this->request->getUri()->getPath());
 
 $this->append('action-buttons');
 $toolsButton = $this->Html->link(__d('croogo', 'Tools'), '#', [

--- a/Blocks/src/Template/Admin/Blocks/form.ctp
+++ b/Blocks/src/Template/Admin/Blocks/form.ctp
@@ -7,10 +7,10 @@ $this->extend('Croogo/Core./Common/admin_edit');
 $this->Breadcrumbs->add(__d('croogo', 'Blocks'), ['action' => 'index']);
 
 if ($this->request->params['action'] == 'edit') {
-    $this->Breadcrumbs->add($block->title, $this->request->here());
+    $this->Breadcrumbs->add($block->title, $this->request->getRequestTarget());
 }
 if ($this->request->params['action'] == 'add') {
-    $this->Breadcrumbs->add(__d('croogo', 'Add'), $this->request->here());
+    $this->Breadcrumbs->add(__d('croogo', 'Add'), $this->request->getRequestTarget());
 }
 
 $this->append('form-start', $this->Form->create($block, [

--- a/Blocks/src/Template/Admin/Blocks/index.ctp
+++ b/Blocks/src/Template/Admin/Blocks/index.ctp
@@ -6,7 +6,7 @@ $this->Croogo->adminScript('Croogo/Blocks.admin');
 
 $this->extend('Croogo/Core./Common/admin_index');
 
-$this->Breadcrumbs->add(__d('croogo', 'Blocks'), $this->request->url);
+$this->Breadcrumbs->add(__d('croogo', 'Blocks'), $this->request->getUri()->getPath());
 
 $this->append('form-start', $this->Form->create(null, [
     'url' => ['action' => 'process'],

--- a/Blocks/src/Template/Admin/Regions/form.ctp
+++ b/Blocks/src/Template/Admin/Regions/form.ctp
@@ -12,11 +12,11 @@ $this->Breadcrumbs->add(__d('croogo', 'Blocks'), [
     ]);
 
 if ($this->request->params['action'] == 'edit') {
-    $this->Breadcrumbs->add($region->title, $this->request->here());
+    $this->Breadcrumbs->add($region->title, $this->request->getRequestTarget());
 }
 
 if ($this->request->params['action'] == 'add') {
-    $this->Breadcrumbs->add(__d('croogo', 'Add'), $this->request->here());
+    $this->Breadcrumbs->add(__d('croogo', 'Add'), $this->request->getRequestTarget());
 }
 
 $this->append('form-start', $this->Form->create($region));

--- a/Blocks/src/Template/Admin/Regions/index.ctp
+++ b/Blocks/src/Template/Admin/Regions/index.ctp
@@ -1,5 +1,5 @@
 <?php
 $this->extend('Croogo/Core./Common/admin_index');
 $this->Breadcrumbs->add(__d('croogo', 'Blocks'), ['controller' => 'blocks', 'action' => 'index'])
-    ->add(__d('croogo', 'Regions'), $this->request->url);
+    ->add(__d('croogo', 'Regions'), $this->request->getUri()->getPath());
 ?>

--- a/Comments/src/Template/Admin/Comments/index.ctp
+++ b/Comments/src/Template/Admin/Comments/index.ctp
@@ -9,14 +9,14 @@ $this->Breadcrumbs->add(__d('croogo', 'Content'), ['plugin' => 'Croogo/Nodes', '
 if (isset($criteria['Comment.status'])) {
     $this->Breadcrumbs->add(__d('croogo', 'Comments'), ['action' => 'index']);
     if ($criteria['Comment.status'] == '1') {
-        $this->Breadcrumbs->add(__d('croogo', 'Published'), $this->request->here());
+        $this->Breadcrumbs->add(__d('croogo', 'Published'), $this->request->getRequestTarget());
         $this->assign('title', __d('croogo', 'Comments: Published'));
     } else {
-        $this->Breadcrumbs->add(__d('croogo', 'Awaiting approval'), $this->request->here());
+        $this->Breadcrumbs->add(__d('croogo', 'Awaiting approval'), $this->request->getRequestTarget());
         $this->assign('title', __d('croogo', 'Comments: Published'));
     }
 } else {
-    $this->Breadcrumbs->add(__d('croogo', 'Comments'), $this->request->here());
+    $this->Breadcrumbs->add(__d('croogo', 'Comments'), $this->request->getRequestTarget());
 }
 
 $this->append('table-footer', $this->element('Croogo/Core.admin/modal', array(

--- a/Contacts/src/Template/Admin/Contacts/form.ctp
+++ b/Contacts/src/Template/Admin/Contacts/form.ctp
@@ -5,11 +5,11 @@ $this->extend('Croogo/Core./Common/admin_edit');
 $this->Breadcrumbs->add(__d('croogo', 'Contacts'), ['controller' => 'contacts', 'action' => 'index']);
 
 if ($this->request->params['action'] == 'edit') {
-    $this->Breadcrumbs->add($contact->title, $this->request->here());
+    $this->Breadcrumbs->add($contact->title, $this->request->getRequestTarget());
 }
 
 if ($this->request->params['action'] == 'add') {
-    $this->Breadcrumbs->add(__d('croogo', 'Add'), $this->request->here());
+    $this->Breadcrumbs->add(__d('croogo', 'Add'), $this->request->getRequestTarget());
 }
 
 $this->append('form-start', $this->Form->create($contact));

--- a/Contacts/src/Template/Admin/Contacts/index.ctp
+++ b/Contacts/src/Template/Admin/Contacts/index.ctp
@@ -1,3 +1,3 @@
 <?php
 $this->extend('Croogo/Core./Common/admin_index');
-$this->Breadcrumbs->add(__d('croogo', 'Contacts'), $this->request->url);
+$this->Breadcrumbs->add(__d('croogo', 'Contacts'), $this->request->getUri()->getPath());

--- a/Contacts/src/Template/Admin/Messages/form.ctp
+++ b/Contacts/src/Template/Admin/Messages/form.ctp
@@ -8,7 +8,7 @@ $this->Breadcrumbs->add(__d('croogo', 'Contacts'),
         ['plugin' => 'Croogo/Contacts', 'controller' => 'Messages', 'action' => 'index']);
 
 if ($this->request->params['action'] == 'edit') {
-    $this->Breadcrumbs->add($message->title, $this->request->here());
+    $this->Breadcrumbs->add($message->title, $this->request->getRequestTarget());
 }
 
 $this->append('form-start', $this->Form->create($message));

--- a/Contacts/src/Template/Admin/Messages/index.ctp
+++ b/Contacts/src/Template/Admin/Messages/index.ctp
@@ -11,14 +11,14 @@ $status = $this->request->query('status');
 if (isset($status)) {
     $this->Breadcrumbs->add(__d('croogo', 'Messages'), ['action' => 'index']);
     if ($status == '1') {
-        $this->Breadcrumbs->add(__d('croogo', 'Read'), $this->request->url);
+        $this->Breadcrumbs->add(__d('croogo', 'Read'), $this->request->getUri()->getPath());
         $this->assign('title', __d('croogo', 'Messages: Read'));
     } else {
-        $this->Breadcrumbs->add(__d('croogo', 'Unread'), $this->request->url);
+        $this->Breadcrumbs->add(__d('croogo', 'Unread'), $this->request->getUri()->getPath());
         $this->assign('title', __d('croogo', 'Messages: Unread'));
     }
 } else {
-    $this->Breadcrumbs->add(__d('croogo', 'Messages'), $this->request->url);
+    $this->Breadcrumbs->add(__d('croogo', 'Messages'), $this->request->getUri()->getPath());
 }
 
 $this->append('table-footer', $this->element('admin/modal', [

--- a/Contacts/src/Template/Admin/Messages/view.ctp
+++ b/Contacts/src/Template/Admin/Messages/view.ctp
@@ -5,7 +5,7 @@ $this->extend('Croogo/Core./Common/admin_view');
 $this->Breadcrumbs
     ->add(__d('croogo', 'Messages'), ['action' => 'index']);
 
-    $this->Breadcrumbs->add($message->title, $this->request->here());
+    $this->Breadcrumbs->add($message->title, $this->request->getRequestTarget());
 
 $this->append('action-buttons');
     echo $this->Croogo->adminAction(__('List Messages'), ['action' => 'index']);

--- a/Dashboards/src/Template/Admin/Dashboards/dashboard.ctp
+++ b/Dashboards/src/Template/Admin/Dashboards/dashboard.ctp
@@ -3,7 +3,7 @@
 $this->Croogo->adminScript('Croogo/Dashboards.admin');
 $this->Html->css('Croogo/Dashboards.admin', array('block' => true));
 
-$this->Breadcrumbs  ->add(__d('croogo', 'Dashboard'), $this->request->here());
+$this->Breadcrumbs  ->add(__d('croogo', 'Dashboard'), $this->request->getRequestTarget());
 
 echo $this->Dashboards->dashboards();
 

--- a/Example/src/Template/Admin/Example/rte_example.ctp
+++ b/Example/src/Template/Admin/Example/rte_example.ctp
@@ -7,7 +7,7 @@ use Cake\Utility\Inflector;
 $this->extend('Croogo/Core./Common/admin_index');
 $this->Breadcrumbs
     ->add('Example', array('controller' => 'example', 'action' => 'index'))
-    ->add('RTE Example', $this->request->here());
+    ->add('RTE Example', $this->request->getRequestTarget());
 
 echo $this->Form->create('Example');
 

--- a/Extensions/src/Template/Admin/Locales/add.ctp
+++ b/Extensions/src/Template/Admin/Locales/add.ctp
@@ -6,7 +6,7 @@ $this->Breadcrumbs->add(__d('croogo', 'Extensions'),
     ['plugin' => 'Croogo/Extensions', 'controller' => 'extensions_plugins', 'action' => 'index'])
     ->add(__d('croogo', 'Locales'),
         ['plugin' => 'Croogo/Extensions', 'controller' => 'extensions_locales', 'action' => 'index'])
-    ->add(__d('croogo', 'Upload'), $this->request->here());
+    ->add(__d('croogo', 'Upload'), $this->request->getRequestTarget());
 
 $this->append('form-start', $this->Form->create(null, [
     'url' => [

--- a/Extensions/src/Template/Admin/Locales/edit.ctp
+++ b/Extensions/src/Template/Admin/Locales/edit.ctp
@@ -5,7 +5,7 @@ $this->extend('/Common/admin_edit');
 $this->Breadcrumbs
     ->add(__d('croogo', 'Extensions'), array('plugin' => 'extensions', 'controller' => 'extensions_plugins', 'action' => 'index'))
     ->add(__d('croogo', 'Locales'), array('plugin' => 'extensions', 'controller' => 'extensions_locales', 'action' => 'index'))
-    ->add($this->request->params['pass'][0], $this->request->here());
+    ->add($this->request->params['pass'][0], $this->request->getRequestTarget());
 
 $this->append('form-start', $this->Form->create('Locale', array(
     'url' => array(

--- a/Extensions/src/Template/Admin/Locales/index.ctp
+++ b/Extensions/src/Template/Admin/Locales/index.ctp
@@ -6,7 +6,7 @@ $this->assign('title', __d('croogo', 'Locales'));
 
 $this->Breadcrumbs
     ->add(__d('croogo', 'Extensions'), array('plugin' => 'Croogo/Extensions', 'controller' => 'Plugins', 'action' => 'index'))
-    ->add(__d('croogo', 'Locales'), $this->request->url);
+    ->add(__d('croogo', 'Locales'), $this->request->getUri()->getPath());
 
 $this->append('action-buttons');
     echo $this->Croogo->adminAction(__d('croogo', 'Upload'),

--- a/Extensions/src/Template/Admin/Plugins/add.ctp
+++ b/Extensions/src/Template/Admin/Plugins/add.ctp
@@ -2,10 +2,10 @@
 
 $this->extend('/Common/admin_edit');
 
-$this->Breadcrumbs->add(__d('croogo', 'Extensions'), $this->request->here())
+$this->Breadcrumbs->add(__d('croogo', 'Extensions'), $this->request->getRequestTarget())
     ->add(__d('croogo', 'Plugins'),
         ['plugin' => 'Croogo/Extensions', 'controller' => 'Plugins', 'action' => 'index'])
-    ->add(__d('croogo', 'Upload'), $this->request->here());
+    ->add(__d('croogo', 'Upload'), $this->request->getRequestTarget());
 
 $this->append('form-start', $this->Form->create(null, [
     'url' => [

--- a/Extensions/src/Template/Admin/Plugins/index.ctp
+++ b/Extensions/src/Template/Admin/Plugins/index.ctp
@@ -4,8 +4,8 @@ $this->extend('Croogo/Core./Common/admin_index');
 
 $this->assign('title', __d('croogo', 'Plugins'));
 
-$this->Breadcrumbs->add(__d('croogo', 'Extensions'), $this->request->url)
-    ->add(__d('croogo', 'Plugins'), $this->request->url);
+$this->Breadcrumbs->add(__d('croogo', 'Extensions'), $this->request->getUri()->getPath())
+    ->add(__d('croogo', 'Plugins'), $this->request->getUri()->getPath());
 
 $this->start('action-buttons');
 echo $this->Croogo->adminAction(__d('croogo', 'Upload'), ['action' => 'add'], ['class' => 'btn btn-success']);

--- a/Extensions/src/Template/Admin/Themes/add.ctp
+++ b/Extensions/src/Template/Admin/Themes/add.ctp
@@ -6,7 +6,7 @@ $this->Breadcrumbs->add(__d('croogo', 'Extensions'),
         ['plugin' => 'Croogo/Extensions', 'controller' => 'extensions_plugins', 'action' => 'index'])
     ->add(__d('croogo', 'Themes'),
         ['plugin' => 'Croogo/Extensions', 'controller' => 'extensions_themes', 'action' => 'index'])
-    ->add(__d('croogo', 'Upload'), $this->request->here());
+    ->add(__d('croogo', 'Upload'), $this->request->getRequestTarget());
 
 $this->append('form-start', $this->Form->create(null, [
     'url' => [

--- a/Extensions/src/Template/Admin/Themes/index.ctp
+++ b/Extensions/src/Template/Admin/Themes/index.ctp
@@ -8,7 +8,7 @@ $this->assign('title', __d('croogo', 'Themes'));
 
 $this->Breadcrumbs->add(__d('croogo', 'Extensions'),
         ['plugin' => 'Croogo/Extensions', 'controller' => 'extensionsPlugins', 'action' => 'index'])
-    ->add(__d('croogo', 'Themes'), $this->request->url);
+    ->add(__d('croogo', 'Themes'), $this->request->getUri()->getPath());
 
 $this->start('action-buttons');
 echo $this->Croogo->adminAction(__d('croogo', 'Upload'), ['action' => 'add'], ['class' => 'btn btn-success']);

--- a/FileManager/src/Template/Admin/Attachments/add.ctp
+++ b/FileManager/src/Template/Admin/Attachments/add.ctp
@@ -5,7 +5,7 @@ $this->extend('Croogo/Core./Common/admin_edit');
 
 $this->Breadcrumbs->add(__d('croogo', 'Attachments'),
         ['plugin' => 'Croogo/FileManager', 'controller' => 'attachments', 'action' => 'index'])
-    ->add(__d('croogo', 'Upload'), $this->request->here());
+    ->add(__d('croogo', 'Upload'), $this->request->getRequestTarget());
 
 $this->append('form-start', $this->Form->create($attachment, [
     'type' => 'file',

--- a/FileManager/src/Template/Admin/Attachments/edit.ctp
+++ b/FileManager/src/Template/Admin/Attachments/edit.ctp
@@ -5,7 +5,7 @@ $this->extend('Croogo/Core./Common/admin_edit');
 
 $this->Breadcrumbs->add(__d('croogo', 'Attachments'),
         ['plugin' => 'Croogo/FileManager', 'controller' => 'attachments', 'action' => 'index'])
-    ->add($attachment->title, $this->request->here());
+    ->add($attachment->title, $this->request->getRequestTarget());
 
 $this->append('form-start', $this->Form->create($attachment));
 

--- a/FileManager/src/Template/Admin/Attachments/index.ctp
+++ b/FileManager/src/Template/Admin/Attachments/index.ctp
@@ -6,7 +6,7 @@
 $this->assign('title', __d('croogo', 'Attachments'));
 $this->extend('Croogo/Core./Common/admin_index');
 
-$this->Breadcrumbs->add(__d('croogo', 'Attachments'), $this->request->url);
+$this->Breadcrumbs->add(__d('croogo', 'Attachments'), $this->request->getUri()->getPath());
 
 $this->Croogo->adminScript('Croogo/FileManager.admin');
 $this->Html->script([

--- a/FileManager/src/Template/Admin/FileManager/browse.ctp
+++ b/FileManager/src/Template/Admin/FileManager/browse.ctp
@@ -3,7 +3,7 @@
 $this->extend('Croogo/Core./Common/admin_index');
 
 $this->assign('title', __d('croogo', 'File Manager'));
-$this->Breadcrumbs->add(__d('croogo', 'File Manager'), $this->request->here());
+$this->Breadcrumbs->add(__d('croogo', 'File Manager'), $this->request->getRequestTarget());
 
 ?>
 

--- a/FileManager/src/Template/Admin/FileManager/create_directory.ctp
+++ b/FileManager/src/Template/Admin/FileManager/create_directory.ctp
@@ -7,7 +7,7 @@ $this->extend('Croogo/Core./Common/admin_edit');
 
 $this->Breadcrumbs->add(__d('croogo', 'File Manager'),
     ['plugin' => 'Croogo/FileManager', 'controller' => 'fileManager', 'action' => 'browse'])
-    ->add(__d('croogo', 'Create Directory'), $this->request->here());
+    ->add(__d('croogo', 'Create Directory'), $this->request->getRequestTarget());
 
 $this->append('form-start', $this->Form->create(null));
 

--- a/FileManager/src/Template/Admin/FileManager/create_file.ctp
+++ b/FileManager/src/Template/Admin/FileManager/create_file.ctp
@@ -5,7 +5,7 @@ $this->extend('Croogo/Core./Common/admin_edit');
 
 $this->Breadcrumbs->add(__d('croogo', 'File Manager'),
         ['plugin' => 'Croogo/FileManager', 'controller' => 'FileManager', 'action' => 'browse'])
-    ->add(__d('croogo', 'Create File'), $this->request->here());
+    ->add(__d('croogo', 'Create File'), $this->request->getRequestTarget());
 
 $this->start('page-heading');
 echo $this->element('Croogo/FileManager.admin/breadcrumbs');

--- a/FileManager/src/Template/Admin/FileManager/edit_file.ctp
+++ b/FileManager/src/Template/Admin/FileManager/edit_file.ctp
@@ -8,7 +8,7 @@ $this->extend('Croogo/Core./Common/admin_edit');
 
 $this->Breadcrumbs->add(__d('croogo', 'File Manager'),
         ['plugin' => 'Croogo/FileManager', 'controller' => 'fileManager', 'action' => 'browse'])
-    ->add(basename($absolutefilepath), $this->request->here());
+    ->add(basename($absolutefilepath), $this->request->getRequestTarget());
 
 $this->start('page-heading');
 echo $this->element('Croogo/FileManager.admin/breadcrumbs');

--- a/FileManager/src/Template/Admin/FileManager/rename.ctp
+++ b/FileManager/src/Template/Admin/FileManager/rename.ctp
@@ -4,7 +4,7 @@ $this->extend('Croogo/Core./Common/admin_edit');
 
 $this->Breadcrumbs->add(__d('croogo', 'File Manager'),
     ['plugin' => 'Croogo/FileManager', 'controller' => 'fileManager', 'action' => 'browse'])
-    ->add(__d('croogo', 'Rename'), $this->request->here());
+    ->add(__d('croogo', 'Rename'), $this->request->getRequestTarget());
 
 $this->start('page-heading');
 echo $this->element('Croogo/FileManager.admin/breadcrumbs');

--- a/FileManager/src/Template/Admin/FileManager/upload.ctp
+++ b/FileManager/src/Template/Admin/FileManager/upload.ctp
@@ -4,7 +4,7 @@ $this->extend('Croogo/Core./Common/admin_edit');
 
 $this->Breadcrumbs->add(__d('croogo', 'File Manager'),
     ['plugin' => 'Croogo/FileManager', 'controller' => 'fileManager', 'action' => 'browse'])
-    ->add(__d('croogo', 'Upload'), $this->request->here());
+    ->add(__d('croogo', 'Upload'), $this->request->getRequestTarget());
 
 $this->start('page-heading');
 echo $this->element('Croogo/FileManager.admin/breadcrumbs');

--- a/Menus/src/Template/Admin/Links/form.ctp
+++ b/Menus/src/Template/Admin/Links/form.ctp
@@ -12,7 +12,7 @@ if ($this->request->params['action'] == 'add') {
                 'action' => 'index',
                 '?' => ['menu_id' => $menu->id],
             ])
-        ->add(__d('croogo', 'Add'), $this->request->here());
+        ->add(__d('croogo', 'Add'), $this->request->getRequestTarget());
     $formUrl = [
         'action' => 'add',
         $menu->id,
@@ -24,7 +24,7 @@ if ($this->request->params['action'] == 'edit') {
             'action' => 'index',
             '?' => ['menu_id' => $menu->id],
         ])
-        ->add($link->title, $this->request->here());
+        ->add($link->title, $this->request->getRequestTarget());
     $formUrl = [
         'action' => 'edit',
         '?' => [

--- a/Menus/src/Template/Admin/Links/index.ctp
+++ b/Menus/src/Template/Admin/Links/index.ctp
@@ -8,7 +8,7 @@ $this->Croogo->adminscript('Croogo/Menus.admin');
 $this->extend('Croogo/Core./Common/admin_index');
 
 $this->Breadcrumbs->add(__d('croogo', 'Menus'), ['controller' => 'Menus', 'action' => 'index'])
-    ->add(__d('croogo', $menu->title), $this->request->here());
+    ->add(__d('croogo', $menu->title), $this->request->getRequestTarget());
 
 $this->append('action-buttons');
 echo $this->Croogo->adminAction(__d('croogo', 'New link'), ['action' => 'add', 'menu_id' => $menu->id], ['button' => 'success']);

--- a/Menus/src/Template/Admin/Menus/form.ctp
+++ b/Menus/src/Template/Admin/Menus/form.ctp
@@ -7,13 +7,13 @@ $this->extend('Croogo/Core./Common/admin_edit');
 $this->Breadcrumbs->add(__d('croogo', 'Menus'), ['action' => 'index']);
 
 if ($this->request->params['action'] == 'edit') {
-    $this->Breadcrumbs->add($menu->title, $this->request->here());
+    $this->Breadcrumbs->add($menu->title, $this->request->getRequestTarget());
 
     $this->assign('title', __d('croogo', 'Edit Menu'));
 }
 
 if ($this->request->params['action'] == 'add') {
-    $this->Breadcrumbs->add(__d('croogo', 'Add'), $this->request->here());
+    $this->Breadcrumbs->add(__d('croogo', 'Add'), $this->request->getRequestTarget());
 
     $this->assign('title', __d('croogo', 'Add Menu'));
 }

--- a/Menus/src/Template/Admin/Menus/index.ctp
+++ b/Menus/src/Template/Admin/Menus/index.ctp
@@ -4,7 +4,7 @@ use Croogo\Core\Status;
 
 $this->extend('Croogo/Core./Common/admin_index');
 
-$this->Breadcrumbs->add(__d('croogo', 'Menus'), $this->request->url);
+$this->Breadcrumbs->add(__d('croogo', 'Menus'), $this->request->getUri()->getPath());
 
 $this->start('table-heading');
 $tableHeaders = $this->Html->tableHeaders([

--- a/Nodes/src/Template/Admin/Nodes/create.ctp
+++ b/Nodes/src/Template/Admin/Nodes/create.ctp
@@ -5,7 +5,7 @@ $this->assign('title', __d('croogo', 'Create content'));
 <?php
 $this->Breadcrumbs
     ->add(__d('croogo', 'Content'), ['action' => 'index'])
-    ->add(__d('croogo', 'Create'), $this->request->here());
+    ->add(__d('croogo', 'Create'), $this->request->getRequestTarget());
 
 ?>
 <div class="<?= $this->Theme->getCssClass('row') ?>">

--- a/Nodes/src/Template/Admin/Nodes/form.ctp
+++ b/Nodes/src/Template/Admin/Nodes/form.ctp
@@ -11,11 +11,11 @@ if ($this->request->params['action'] == 'add') {
     $this->assign('title', __d('croogo', 'Create content: %s', $type->title));
 
     $this->Breadcrumbs->add(__d('croogo', 'Create'), ['action' => 'create'])
-        ->add($type->title, $this->request->here());
+        ->add($type->title, $this->request->getRequestTarget());
 }
 
 if ($this->request->params['action'] == 'edit') {
-    $this->Breadcrumbs->add($node->title, $this->request->here());
+    $this->Breadcrumbs->add($node->title, $this->request->getRequestTarget());
 }
 
 $this->append('form-start', $this->Form->create($node, [

--- a/Nodes/src/Template/Admin/Nodes/index.ctp
+++ b/Nodes/src/Template/Admin/Nodes/index.ctp
@@ -8,7 +8,7 @@ $this->extend('Croogo/Core./Common/admin_index');
 $this->Croogo->adminScript('Croogo/Nodes.admin');
 
 $this->Breadcrumbs
-    ->add(__d('croogo', 'Content'), $this->request->url);
+    ->add(__d('croogo', 'Content'), $this->request->getUri()->getPath());
 
 $this->append('action-buttons');
 echo $this->Croogo->adminAction(__d('croogo', 'Create content'), ['action' => 'create'], ['button' => 'success']);

--- a/Settings/src/Template/Admin/Languages/form.ctp
+++ b/Settings/src/Template/Admin/Languages/form.ctp
@@ -12,7 +12,7 @@ if ($this->request->params['action'] == 'edit') {
 }
 
 if ($this->request->params['action'] == 'add') {
-    $this->Breadcrumbs->add(__d('croogo', 'Add'), $this->request->here());
+    $this->Breadcrumbs->add(__d('croogo', 'Add'), $this->request->getRequestTarget());
 }
 
 $this->append('form-start', $this->Form->create($language));

--- a/Settings/src/Template/Admin/Languages/index.ctp
+++ b/Settings/src/Template/Admin/Languages/index.ctp
@@ -4,7 +4,7 @@ $this->extend('Croogo/Core./Common/admin_index');
 
 $this->Breadcrumbs->add(__d('croogo', 'Settings'),
     ['plugin' => 'Croogo/Settings', 'controller' => 'Settings', 'action' => 'prefix', 'Site'])
-    ->add(__d('croogo', 'Languages'), $this->request->url);
+    ->add(__d('croogo', 'Languages'), $this->request->getUri()->getPath());
 
 $tableHeaders = $this->Html->tableHeaders([
     $this->Paginator->sort('title', __d('croogo', 'Title')),

--- a/Settings/src/Template/Admin/Settings/dashboard.ctp
+++ b/Settings/src/Template/Admin/Settings/dashboard.ctp
@@ -1,5 +1,5 @@
 <h2 class="hidden-md-up"><?php echo $title_for_layout; ?></h2>
 <?php
 $this->Breadcrumbs
-    ->add(__d('croogo', 'Dashboard'), $this->request->here());
+    ->add(__d('croogo', 'Dashboard'), $this->request->getRequestTarget());
 ?>

--- a/Settings/src/Template/Admin/Settings/form.ctp
+++ b/Settings/src/Template/Admin/Settings/form.ctp
@@ -9,11 +9,11 @@ $this->Breadcrumbs
     ]);
 
 if ($this->request->param('action') == 'edit') {
-    $this->Breadcrumbs->add($setting->key, $this->request->here());
+    $this->Breadcrumbs->add($setting->key, $this->request->getRequestTarget());
 }
 
 if ($this->request->param('action') == 'add') {
-    $this->Breadcrumbs->add(__d('croogo', 'Add'), $this->request->here());
+    $this->Breadcrumbs->add(__d('croogo', 'Add'), $this->request->getRequestTarget());
 }
 
 $this->append('form-start', $this->Form->create($setting, [

--- a/Settings/src/Template/Admin/Settings/prefix.ctp
+++ b/Settings/src/Template/Admin/Settings/prefix.ctp
@@ -6,7 +6,7 @@ $this->extend('Croogo/Core./Common/admin_edit');
 
 $this->Breadcrumbs->add(__d('croogo', 'Settings'),
     ['plugin' => 'Croogo/Settings', 'controller' => 'Settings', 'action' => 'index'])
-    ->add($prefix, $this->request->here());
+    ->add($prefix, $this->request->getRequestTarget());
 
 $this->assign('form-start', $this->Form->create(null, [
     'class' => 'protected-form',

--- a/Taxonomy/src/Template/Admin/Terms/form.ctp
+++ b/Taxonomy/src/Template/Admin/Terms/form.ctp
@@ -18,7 +18,7 @@ if ($this->request->params['action'] == 'add') {
     $this->Breadcrumbs->add(__d('croogo', 'Vocabularies'),
         ['controller' => 'Vocabularies', 'action' => 'index', $vocabulary->id])
         ->add($vocabulary->title, ['action' => 'index'])
-        ->add(__d('croogo', 'Add'), $this->request->here());
+        ->add(__d('croogo', 'Add'), $this->request->getRequestTarget());
 }
 
 $this->set('cancelUrl', ['action' => 'index', $vocabularyId]);

--- a/Taxonomy/src/Template/Admin/Terms/index.ctp
+++ b/Taxonomy/src/Template/Admin/Terms/index.ctp
@@ -8,7 +8,7 @@ $this->Breadcrumbs->add(__d('croogo', 'Content'),
         ['plugin' => 'Croogo/Nodes', 'controller' => 'Nodes', 'action' => 'index'])
     ->add(__d('croogo', 'Vocabularies'),
         ['plugin' => 'Croogo/Taxonomy', 'controller' => 'Vocabularies', 'action' => 'index'])
-    ->add($vocabulary->title, $this->request->here());
+    ->add($vocabulary->title, $this->request->getRequestTarget());
 
 $this->append('action-buttons');
 echo $this->Croogo->adminAction(__d('croogo', 'Create term'), ['action' => 'add', $vocabulary->id], ['class' => 'btn btn-success']);

--- a/Taxonomy/src/Template/Admin/Types/form.ctp
+++ b/Taxonomy/src/Template/Admin/Types/form.ctp
@@ -13,7 +13,7 @@ if ($this->request->params['action'] == 'edit') {
 }
 
 if ($this->request->params['action'] == 'add') {
-    $this->Breadcrumbs->add(__d('croogo', 'Add'), $this->request->here());
+    $this->Breadcrumbs->add(__d('croogo', 'Add'), $this->request->getRequestTarget());
 }
 
 $this->append('form-start', $this->Form->create($type));

--- a/Taxonomy/src/Template/Admin/Types/index.ctp
+++ b/Taxonomy/src/Template/Admin/Types/index.ctp
@@ -1,6 +1,6 @@
 <?php
 $this->Breadcrumbs->add(__d('croogo', 'Content'),
         ['plugin' => 'Croogo/Nodes', 'controller' => 'Nodes', 'action' => 'index'])
-    ->add(__d('croogo', 'Types'), $this->request->here());
+    ->add(__d('croogo', 'Types'), $this->request->getRequestTarget());
 
 $this->extend('Croogo/Core./Common/admin_index');

--- a/Taxonomy/src/Template/Admin/Vocabularies/form.ctp
+++ b/Taxonomy/src/Template/Admin/Vocabularies/form.ctp
@@ -17,7 +17,7 @@ if ($this->request->params['action'] == 'add') {
     $this->assign('title', __d('croogo', 'Add Vocabulary'));
 
     $this->Breadcrumbs->add(__d('croogo', 'Vocabularies'), ['action' => 'index'])
-        ->add(__d('croogo', 'Add'), $this->request->here());
+        ->add(__d('croogo', 'Add'), $this->request->getRequestTarget());
 }
 
 $this->append('form-start', $this->Form->create($vocabulary, [

--- a/Taxonomy/src/Template/Admin/Vocabularies/index.ctp
+++ b/Taxonomy/src/Template/Admin/Vocabularies/index.ctp
@@ -4,7 +4,7 @@ $this->extend('Croogo/Core./Common/admin_index');
 
 $this->Breadcrumbs->add(__d('croogo', 'Content'),
         ['plugin' => 'Croogo/Nodes', 'controller' => 'Nodes', 'action' => 'index'])
-    ->add(__d('croogo', 'Vocabularies'), $this->request->here());
+    ->add(__d('croogo', 'Vocabularies'), $this->request->getRequestTarget());
 
 $this->start('table-heading');
 $tableHeaders = $this->Html->tableHeaders([

--- a/Translate/src/Template/Admin/Translate/edit.ctp
+++ b/Translate/src/Template/Admin/Translate/edit.ctp
@@ -21,7 +21,7 @@ $this->Breadcrumbs
             ],
         )
     )
-    ->add(__d('croogo', 'Translate'), $this->request->here());
+    ->add(__d('croogo', 'Translate'), $this->request->getRequestTarget());
 
 $this->append('form-start', $this->Form->create($entity, array(
     'url' => array(

--- a/Translate/src/Template/Admin/Translate/index.ctp
+++ b/Translate/src/Template/Admin/Translate/index.ctp
@@ -27,7 +27,7 @@ $this->Breadcrumbs
             $record->id,
         )
     )
-    ->add(__d('croogo', 'Translations'), $this->request->here());
+    ->add(__d('croogo', 'Translations'), $this->request->getRequestTarget());
 
 $this->start('action-buttons');
     $translateButton = $this->Html->link(

--- a/Users/src/Template/Admin/Roles/form.ctp
+++ b/Users/src/Template/Admin/Roles/form.ctp
@@ -5,11 +5,11 @@ $this->Breadcrumbs
     ->add(__d('croogo', 'Roles'), ['plugin' => 'Croogo/Users', 'controller' => 'Roles', 'action' => 'index']);
 
 if ($this->request->param('action') == 'edit') {
-    $this->Breadcrumbs->add($role->title, $this->request->here());
+    $this->Breadcrumbs->add($role->title, $this->request->getRequestTarget());
 }
 
 if ($this->request->param('action') == 'add') {
-    $this->Breadcrumbs->add(__d('croogo', 'Add'), $this->request->here());
+    $this->Breadcrumbs->add(__d('croogo', 'Add'), $this->request->getRequestTarget());
 }
 
 $this->assign('form-start', $this->Form->create($role));

--- a/Users/src/Template/Admin/Roles/index.ctp
+++ b/Users/src/Template/Admin/Roles/index.ctp
@@ -3,4 +3,4 @@ $this->extend('Croogo/Core./Common/admin_index');
 
 $this->Breadcrumbs
     ->add(__d('croogo', 'Users'), ['plugin' => 'Croogo/Users', 'controller' => 'Users', 'action' => 'index'])
-    ->add(__d('croogo', 'Roles'), $this->request->url);
+    ->add(__d('croogo', 'Roles'), $this->request->getUri()->getPath());

--- a/Users/src/Template/Admin/Users/form.ctp
+++ b/Users/src/Template/Admin/Users/form.ctp
@@ -9,11 +9,11 @@ $this->Breadcrumbs->add(__d('croogo', 'Users'),
         ['plugin' => 'Croogo/Users', 'controller' => 'Users', 'action' => 'index']);
 
 if ($this->request->param('action') == 'edit') {
-    $this->Breadcrumbs->add($user->name, $this->request->here());
+    $this->Breadcrumbs->add($user->name, $this->request->getRequestTarget());
     $this->assign('title', __d('croogo', 'Edit user %s', $user->username));
 } else {
     $this->assign('title', __d('croogo', 'New user'));
-    $this->Breadcrumbs->add(__d('croogo', 'New user'), $this->request->here());
+    $this->Breadcrumbs->add(__d('croogo', 'New user'), $this->request->getRequestTarget());
 }
 
 $this->start('action-buttons');

--- a/Users/src/Template/Admin/Users/index.ctp
+++ b/Users/src/Template/Admin/Users/index.ctp
@@ -2,4 +2,4 @@
 
 $this->extend('Croogo/Core./Common/admin_index');
 
-$this->Breadcrumbs->add(__d('croogo', 'Users'), $this->request->url);
+$this->Breadcrumbs->add(__d('croogo', 'Users'), $this->request->getUri()->getPath());

--- a/Users/src/Template/Admin/Users/reset_password.ctp
+++ b/Users/src/Template/Admin/Users/reset_password.ctp
@@ -8,7 +8,7 @@ $this->Breadcrumbs
         'action' => 'edit',
         $user->id,
     ])
-    ->add(__d('croogo', 'Reset Password'), $this->request->here());
+    ->add(__d('croogo', 'Reset Password'), $this->request->getRequestTarget());
 $this->assign('form-start', $this->Form->create($user));
 
 $this->start('tab-heading');

--- a/Users/src/Template/Admin/Users/view.ctp
+++ b/Users/src/Template/Admin/Users/view.ctp
@@ -4,7 +4,7 @@ $this->extend('Croogo/Core./Common/admin_view');
 
 $this->Breadcrumbs
     ->add(__d('croogo', 'Users'), ['action' => 'index'])
-    ->add($user->name, $this->request->here());
+    ->add($user->name, $this->request->getRequestTarget());
 
 $this->append('action-buttons');
     echo $this->Croogo->adminAction(__('Edit User'), ['action' => 'edit', $user->id]);


### PR DESCRIPTION
This aims to fix #803 

Tested when running croogo under `croogo3subdir`, eg: http://localhosts/croogo3subdir with the following nginx config:

```nginx
server {
    ...
    location /croogo3subdir {
        root /var/www/html/croogo3subdir/webroot;
        rewrite ^/croogo3subdir/(.+)$ /$1 break;
        try_files $uri $uri/ /croogo3subdir/index.php$is_args$args;
    }

    location ~ \.php$ {
        try_files $uri =404;
        include fastcgi_params;
        fastcgi_pass unix:/var/run/php/php7.0-fpm.sock;
        fastcgi_index index.php;
        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
    }
}
```