### PR TITLE
Expose $statusType for statuses()

### DIFF
--- a/Croogo/View/Helper/CroogoHelper.php
+++ b/Croogo/View/Helper/CroogoHelper.php
@@ -56,8 +56,8 @@ class CroogoHelper extends AppHelper {
 		}
 	}
 
-	public function statuses() {
-		return $this->_CroogoStatus->statuses();
+	public function statuses($statusType = 'publishing') {
+		return $this->_CroogoStatus->statuses($statusType);
 	}
 
 /**


### PR DESCRIPTION
CroogoStatus::statuses() can return different status groups, so allow CroogoHelper::statuses to request specific statusType.