### PR TITLE
Replace Auth::redirect() with Auth::redirectUrl()

### DIFF
--- a/Users/Controller/UsersController.php
+++ b/Users/Controller/UsersController.php
@@ -264,13 +264,13 @@ class UsersController extends UsersAppController {
 					array('class' => 'alert'), 'auth'
 				);
 			}
-			return $this->redirect($this->Auth->redirect());
+			return $this->redirect($this->Auth->redirectUrl());
 		}
 		if ($this->request->is('post')) {
 			Croogo::dispatchEvent('Controller.Users.beforeAdminLogin', $this);
 			if ($this->Auth->login()) {
 				Croogo::dispatchEvent('Controller.Users.adminLoginSuccessful', $this);
-				return $this->redirect($this->Auth->redirect());
+				return $this->redirect($this->Auth->redirectUrl());
 			} else {
 				Croogo::dispatchEvent('Controller.Users.adminLoginFailure', $this);
 				$this->Auth->authError = __d('croogo', 'Incorrect username or password');
@@ -538,7 +538,7 @@ class UsersController extends UsersAppController {
 			Croogo::dispatchEvent('Controller.Users.beforeLogin', $this);
 			if ($this->Auth->login()) {
 				Croogo::dispatchEvent('Controller.Users.loginSuccessful', $this);
-				return $this->redirect($this->Auth->redirect());
+				return $this->redirect($this->Auth->redirectUrl());
 			} else {
 				Croogo::dispatchEvent('Controller.Users.loginFailure', $this);
 				$this->Session->setFlash($this->Auth->authError, 'flash', array('class' => 'error'), 'auth');


### PR DESCRIPTION
According to https://book.cakephp.org/2.0/en/core-libraries/components/authentication.html $this->redirect($this->Auth->redirectUrl()) should be used instead of $this->redirect($this->Auth->redirect()).

Changing this would require CakePHP version 2.3+ ... but would this be a problem?