### PR TITLE
Add space before and after attributes in img

### DIFF
--- a/Croogo/View/Helper/ImageHelper.php
+++ b/Croogo/View/Helper/ImageHelper.php
@@ -129,7 +129,7 @@ class ImageHelper extends Helper {
 			//copy($url, $cachefile);
 		}
 
-		return $this->output(sprintf($this->Html->_tags['image'], $this->webroot($relfile), $this->Html->_parseAttributes($htmlAttributes, null, '', ' ')), $return);
+		return $this->output(sprintf($this->Html->_tags['image'], $this->webroot($relfile), $this->Html->_parseAttributes($htmlAttributes, null, ' ', ' ')), $return);
 	}
 
 /**


### PR DESCRIPTION
Hi,
When we add a pictures using resize function ( $this->Image->resize() ), we see that there is no space between image path in src and the first attribute ex:

<img src="myimg.resized-76x80.jpg"alt="alt example" width="80" height="80" class="img-polaroid" />

 Also that cause HTML validation errors : No space between attributes

The solution is add space in parameter :
$this->Html->_parseAttributes($htmlAttributes, null, ' ', ' ')