### PR TITLE
Node Reordering with Tree Behavior

### DIFF
--- a/Nodes/Controller/NodesController.php
+++ b/Nodes/Controller/NodesController.php
@@ -193,10 +193,11 @@ class NodesController extends NodesAppController {
  * @return void
  */
 	public function admin_moveup($id, $step = 1) {
-		$node = $this->Node->findById($id);
+		$this->Node->id = $id;
+		$type = $this->Node->field('type');
 		$this->Node->Behaviors->attach('Tree', array(
 			'scope' => array(
-				$this->Node->escapeField('type') => $node['Node']['type'],
+				$this->Node->escapeField('type') => $type,
 			),
 		));
 		if ($this->Node->moveUp($id, $step)) {
@@ -214,10 +215,11 @@ class NodesController extends NodesAppController {
  * @param integer $step Step
  */
 	public function admin_movedown($id, $step = 1) {
-		$node = $this->Node->findById($id);
+		$this->Node->id = $id;
+		$type = $this->Node->field('type');
 		$this->Node->Behaviors->attach('Tree', array(
 			'scope' => array(
-				$this->Node->escapeField('type') => $node['Node']['type'],
+				$this->Node->escapeField('type') => $type,
 			),
 		));
 		if ($this->Node->moveDown($id, $step)) {

--- a/Nodes/Controller/NodesController.php
+++ b/Nodes/Controller/NodesController.php
@@ -193,6 +193,12 @@ class NodesController extends NodesAppController {
  * @return void
  */
 	public function admin_moveup($id, $step = 1) {
+		$node = $this->Node->findById($id);
+		$this->Node->Behaviors->attach('Tree', array(
+			'scope' => array(
+				$this->Node->escapeField('type') => $node['Node']['type'],
+			),
+		));
 		if ($this->Node->moveUp($id, $step)) {
 			$this->Session->setFlash(__d('croogo', 'Moved up successfully'), 'flash', array('class' => 'success'));
 		} else {
@@ -208,6 +214,12 @@ class NodesController extends NodesAppController {
  * @param integer $step Step
  */
 	public function admin_movedown($id, $step = 1) {
+		$node = $this->Node->findById($id);
+		$this->Node->Behaviors->attach('Tree', array(
+			'scope' => array(
+				$this->Node->escapeField('type') => $node['Node']['type'],
+			),
+		));
 		if ($this->Node->moveDown($id, $step)) {
 			$this->Session->setFlash(__d('croogo', 'Moved down successfully'), 'flash', array('class' => 'success'));
 		} else {
@@ -248,6 +260,11 @@ class NodesController extends NodesAppController {
 			return $this->redirect(array('action' => 'create'));
 		}
 
+		$Node->Behaviors->attach('Tree', array(
+			'scope' => array(
+				$Node->escapeField('type') => $type['Type']['alias'],
+			),
+		));
 		if (!empty($this->request->data)) {
 			if (isset($this->request->data[$Node->alias]['type'])) {
 				$typeAlias = $this->request->data[$Node->alias]['type'];
@@ -266,12 +283,6 @@ class NodesController extends NodesAppController {
 		}
 
 		$this->set('title_for_layout', __d('croogo', 'Create content: %s', $type['Type']['title']));
-		$Node->type = $type['Type']['alias'];
-		$Node->Behaviors->attach('Tree', array(
-			'scope' => array(
-				$Node->escapeField('type') => $Node->type,
-			),
-		));
 
 		$this->_setCommonVariables($type);
 	}


### PR DESCRIPTION
Similar to PR #790 found in the LinksController, the NodesController is also affected by improper scoping with its use of the TreeBehavior. Links are "scoped" within their containing Menu. Nodes should be "scoped" within their Type.