### PR TITLE
Fix links for Nodes not called `blog`

### DIFF
--- a/Nodes/src/Template/Nodes/index.ctp
+++ b/Nodes/src/Template/Nodes/index.ctp
@@ -26,5 +26,5 @@ endif;
         endforeach;
     ?>
 
-    <div class="paging"><?= $this->Paginator->numbers() ?></div>
+    <div class="paging"><?= $this->Paginator->numbers(["url" => ["type" => $type->alias]]) ?></div>
 </div>

--- a/Nodes/src/Template/Nodes/promoted.ctp
+++ b/Nodes/src/Template/Nodes/promoted.ctp
@@ -26,5 +26,5 @@ $this->assign('title', 'Home');
         endforeach;
     ?>
 
-    <div class="paging"><?= $this->Paginator->numbers() ?></div>
+    <div class="paging"><?= $this->Paginator->numbers(["url" => ["type" => $type->alias]]) ?></div>
 </div>

--- a/Nodes/src/Template/Nodes/search.ctp
+++ b/Nodes/src/Template/Nodes/search.ctp
@@ -28,5 +28,5 @@ $this->assign('title', __d('croogo', 'Search Results: %s', h($q)));
         endforeach;
     ?>
 
-    <div class="paging"><?= $this->Paginator->numbers() ?></div>
+    <div class="paging"><?= $this->Paginator->numbers(["url" => ["type" => $type->alias]]) ?></div>
 </div>

--- a/Nodes/src/Template/Nodes/term.ctp
+++ b/Nodes/src/Template/Nodes/term.ctp
@@ -34,5 +34,5 @@ $this->assign('title', implode (' | ', $titles));
         endforeach;
     ?>
 
-    <div class="paging"><?= $this->Paginator->numbers(["url" => ["term" => $term->slug, "type" => $type->alias]]) ?></div>
+    <div class="paging"><?= $this->Paginator->numbers(["url" => ["slug" => $term->slug, "type" => $type->alias]]) ?></div>
 </div>

--- a/Nodes/src/Template/Nodes/term.ctp
+++ b/Nodes/src/Template/Nodes/term.ctp
@@ -34,5 +34,5 @@ $this->assign('title', implode (' | ', $titles));
         endforeach;
     ?>
 
-    <div class="paging"><?= $this->Paginator->numbers() ?></div>
+    <div class="paging"><?= $this->Paginator->numbers(["url" => ["term" => $term->slug, "type" => $type->alias]]) ?></div>
 </div>


### PR DESCRIPTION
Without these modifications, paginations links cannot be rendered, as routes cannot be inferred without `type` param