### PR TITLE
fix node elements (cakephp 2 legacy)

### DIFF
--- a/Nodes/src/Template/Element/node_info.ctp
+++ b/Nodes/src/Template/Element/node_info.ctp
@@ -2,23 +2,24 @@
 <?php
     $type = $typesForLayout[$this->Nodes->field('type')];
 
-    if ($type['Type']['format_show_author'] || $type['Type']['format_show_date']) {
+    if ($type->format_show_author || $type->format_show_date) {
         echo __d('croogo', 'Posted');
     }
-    if ($type['Type']['format_show_author']) {
+    if ($type->format_show_author) {
         echo ' ' . __d('croogo', 'by') . ' ';
-        if ($this->Nodes->field('User.website') != null) {
-            $author = $this->Html->link($this->Nodes->field('User.name'), $this->Nodes->field('User.website'));
+        if ($this->Nodes->field('user.website') != null) {
+            $author = $this->Html->link($this->Nodes->field('user.name'), $this->Nodes->field('user.website'));
         } else {
-            $author = $this->Nodes->field('User.name');
+            $author = $this->Nodes->field('user.name');
         }
+
         echo $this->Html->tag('span', $author, array(
             'class' => 'author',
         ));
     }
-    if ($type['Type']['format_show_date']) {
+    if ($type->format_show_date) {
         echo ' ' . __d('croogo', 'on') . ' ';
-        echo $this->Html->tag('span', $this->Time->format(Configure::read('Reading.date_time_format'), $this->Nodes->field('created'), null, Configure::read('Site.timezone')), array('class' => 'date'));
+        echo $this->Html->tag('span', $this->Nodes->date($this->Nodes->field('publish_start')), array('class' => 'date'));
     }
 ?>
 </div>

--- a/Nodes/src/Template/Element/node_more_info.ctp
+++ b/Nodes/src/Template/Element/node_more_info.ctp
@@ -2,24 +2,11 @@
 <?php
     $type = $typesForLayout[$this->Nodes->field('type')];
 
-    if (is_array($this->Nodes->node['Taxonomy']) && count($this->Nodes->node['Taxonomy']) > 0) {
-        $nodeTerms = Hash::combine($this->Nodes->node, 'Taxonomy.{n}.Term.slug', 'Taxonomy.{n}.Term.title');
-        $nodeTermLinks = array();
-        if (count($nodeTerms) > 0) {
-            foreach ($nodeTerms as $termSlug => $termTitle) {
-                $nodeTermLinks[] = $this->Html->link($termTitle, array(
-                    'plugin' => 'nodes',
-                    'controller' => 'nodes',
-                    'action' => 'term',
-                    'type' => $this->Nodes->field('type'),
-                    'slug' => $termSlug,
-                ));
-            }
-            echo __d('croogo', 'Posted in') . ' ' . implode(', ', $nodeTermLinks);
-        }
+    if (!empty($this->Nodes->node->taxonomies)) {
+        echo __d('croogo', 'Posted in') . ' ' . implode(', ', $this->Nodes->nodeTermLinks());
     }
 
-    if ($this->request->params['action'] != 'view' && $type['Type']['comment_status']) {
+    if ($this->Nodes->commentsEnabled() && $this->request->params['action'] !== 'view' && $type->comment_status) {
         if (isset($nodeTerms) && count($nodeTerms) > 0) {
             echo ' | ';
         }
@@ -32,7 +19,7 @@
         } else {
             $commentCount = $this->Nodes->field('comment_count') . ' ' . __d('croogo', 'Comments');
         }
-        echo $this->Html->link($commentCount, $this->Html->url($this->Nodes->field('url'), true) . '#comments');
+        echo $this->Html->link($commentCount, array_merge($this->Nodes->field('url')->getUrl()), ['#' => 'comments']);
     }
 ?>
 </div>

--- a/Nodes/src/View/Helper/NodesHelper.php
+++ b/Nodes/src/View/Helper/NodesHelper.php
@@ -8,6 +8,10 @@ use Cake\View\View;
 use Croogo\Core\Croogo;
 use Croogo\Core\Utility\StringConverter;
 use Croogo\Nodes\Model\Entity\Node;
+use Cake\Utility\Hash;
+use Cake\Core\Configure;
+use Cake\Collection\Collection;
+use Cake\Core\Plugin;
 
 /**
  * Nodes Helper
@@ -31,6 +35,8 @@ class NodesHelper extends Helper
     public $helpers = [
         'Croogo/Core.Url',
         'Croogo/Core.Layout',
+        'Croogo/Core.Html',
+        'Time',
     ];
 
 /**
@@ -158,7 +164,7 @@ class NodesHelper extends Helper
             return $this->node->set($field, $value);
         }
 
-        return $this->node->get($field);
+        return Hash::get($this->node, $field);
     }
 
 /**
@@ -264,5 +270,44 @@ class NodesHelper extends Helper
         }
 
         return $this->Url->build($node->url, $full);
+    }
+
+    /**
+     * Return formatted date
+     *
+     * @param \Cake\I18n\FrozenTime $date
+     * @return string
+     */
+    public function date($date)
+    {
+        return $this->Time->format($date, Configure::read('Reading.date_time_format'), null, Configure::read('Site.timezone'));
+    }
+
+    /**
+     * Return all term links
+     *
+     * @return array
+     */
+    public function nodeTermLinks()
+    {
+        return (new Collection($this->node->taxonomies))->map(function ($taxonomy) {
+            return $this->Html->link($taxonomy->term->title, array(
+                'plugin' => 'Croogo/Nodes',
+                'controller' => 'Nodes',
+                'action' => 'term',
+                'type' => $this->field('type'),
+                'slug' => $taxonomy->term->slug,
+            ));
+        })->toArray();
+    }
+
+    /**
+     * Check if comments plugin is enable
+     *
+     * @return bool
+     */
+    public function commentsEnabled()
+    {
+        return Plugin::loaded('Croogo/Comments');
     }
 }

--- a/Nodes/src/View/Helper/NodesHelper.php
+++ b/Nodes/src/View/Helper/NodesHelper.php
@@ -2,16 +2,16 @@
 
 namespace Croogo\Nodes\View\Helper;
 
+use Cake\Collection\Collection;
+use Cake\Core\Configure;
+use Cake\Core\Plugin;
 use Cake\Event\Event;
+use Cake\Utility\Hash;
 use Cake\View\Helper;
 use Cake\View\View;
 use Croogo\Core\Croogo;
 use Croogo\Core\Utility\StringConverter;
 use Croogo\Nodes\Model\Entity\Node;
-use Cake\Utility\Hash;
-use Cake\Core\Configure;
-use Cake\Collection\Collection;
-use Cake\Core\Plugin;
 
 /**
  * Nodes Helper
@@ -205,6 +205,7 @@ class NodesHelper extends Helper
         $options = array_merge($_options, $options);
 
         $excerpt = $this->node->excerpt;
+
         if ($options['body'] && empty($excerpt)) {
             $excerpt = $this->_converter->firstPara(
                 $this->node->body,
@@ -275,7 +276,7 @@ class NodesHelper extends Helper
     /**
      * Return formatted date
      *
-     * @param \Cake\I18n\FrozenTime $date
+     * @param \Cake\I18n\FrozenTime $date date to format
      * @return string
      */
     public function date($date)
@@ -291,13 +292,13 @@ class NodesHelper extends Helper
     public function nodeTermLinks()
     {
         return (new Collection($this->node->taxonomies))->map(function ($taxonomy) {
-            return $this->Html->link($taxonomy->term->title, array(
+            return $this->Html->link($taxonomy->term->title, [
                 'plugin' => 'Croogo/Nodes',
                 'controller' => 'Nodes',
                 'action' => 'term',
                 'type' => $this->field('type'),
                 'slug' => $taxonomy->term->slug,
-            ));
+            ]);
         })->toArray();
     }
 


### PR DESCRIPTION
Fix node elements. Replace cakephp 2 code by cakephp 3 because "node_info" and "node_more_info" are already not displayed.