### PR TITLE
Make URL filter work on redirect routes

### DIFF
--- a/Translate/config/routes.php
+++ b/Translate/config/routes.php
@@ -3,10 +3,15 @@
 use Cake\Routing\RouteBuilder;
 use Croogo\Core\Router;
 
-Router::addUrlFilter(function ($params, $request) {
+Router::addUrlFilter(function ($params, $request = null) {
+    if (!$request) {
+        return $params;
+    }
+
     if ($request->getParam('lang') && !isset($params['lang'])) {
         $params['lang'] = $request->getParam('lang');
     }
+
     return $params;
 });
 


### PR DESCRIPTION
Redirect routes cause the request parameter to be null, this
causes an internal server error as the URL filter in the translate
plugin tries to get a parameter from the request.

This change makes the request parameter optional.