### PR TITLE
Fix: add validate unique slug for terms

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -32,7 +32,6 @@ ADmad <ADmad@users.noreply.github.com>
 Ceeram <c33ram@gmail.com>
 Grégory Salvan <gregory@occi-tech.com>
 Hadrien Collongues <chadrien@chadrien.fr>
-Ivan <gsitex@gmail.com>
 John <john@midianegocios.com.br>
 Lukas Marks <lukas.marks@lumax-web.de>
 Lukas Strassel <lukasstrassel@googlemail.com>

--- a/Core/src/View/Helper/CroogoFormHelper.php
+++ b/Core/src/View/Helper/CroogoFormHelper.php
@@ -255,7 +255,7 @@ class CroogoFormHelper extends FormHelper
         if (!empty($options['fieldAccess'])) {
             $this->_fieldAccess = $this->_setupFieldAccess($options['fieldAccess']);
             $this->_currentRoleId = $this->_View->Layout->getRoleId();
-            unset($options['fieldAcess']);
+            unset($options['fieldAccess']);
         }
         return parent::create($model, $options);
     }

--- a/Extensions/src/Template/Admin/Themes/index.ctp
+++ b/Extensions/src/Template/Admin/Themes/index.ctp
@@ -21,7 +21,7 @@ $this->end() ?>
                 <h3><?= __d('croogo', 'Current Theme') ?></h3>
                 <?php
                 if (isset($currentTheme['screenshot'])):
-                    $file = $this->Url->assetUrl($currentTheme['name'] . '.' . $currentTheme['screenshot']);
+                    $file = $this->Url->assetUrl($currentTheme['name'] . '.' . $currentTheme['screenshot'], ['fullBase' => true]);
                     $imgUrl = $this->Html->thumbnail($file);
                     $link = $this->Html->link($imgUrl, $file, [
                         'escape' => false,

--- a/Menus/src/View/Helper/MenusHelper.php
+++ b/Menus/src/View/Helper/MenusHelper.php
@@ -149,7 +149,11 @@ class MenusHelper extends Helper
         }
         $items = [];
         foreach ($menu['threaded'] as $item) {
-            $items[] = $this->Html->link($item->title, $item->link->getUrl(), [
+            $url = $item->link->getUrl();
+            if (Router::normalize($url) === '/.rss') {
+                $url = '/.rss';
+            }
+            $items[] = $this->Html->link($item->title, $url, [
                 'class' => 'nav-link',
             ]);
         }

--- a/Taxonomy/src/Model/Table/TermsTable.php
+++ b/Taxonomy/src/Model/Table/TermsTable.php
@@ -57,7 +57,18 @@ class TermsTable extends CroogoTable
     {
         $validator
             ->notBlank('title', __d('croogo', 'The title cannot be empty'))
-            ->notBlank('slug', __d('croogo', 'The slug cannot be empty'));
+            ->notBlank('slug', __d('croogo', 'The slug cannot be empty'))
+            ->add(
+                'slug',
+                [
+                'unique' => [
+                    'rule' => 'validateUnique',
+                    'provider' => 'table',
+                    'message' => __d('croogo', 'This slug has already been taken.')
+                    ]
+                ]
+            );
+
         return $validator;
     }
 


### PR DESCRIPTION
Hello :wave: 

Without this fix, when you try to enter the same slug for two terms it crashes (500 internal error) with a SQL constraint error.

Pof.