### PR TITLE
HtmlHelper should escape attributes by default...

### DIFF
--- a/Core/src/View/Helper/CroogoHtmlHelper.php
+++ b/Core/src/View/Helper/CroogoHtmlHelper.php
@@ -224,7 +224,7 @@ class CroogoHtmlHelper extends HtmlHelper
      */
     public function link($title, $url = null, array $options = [], $confirmMessage = false)
     {
-        $defaults = ['escape' => false];
+        $defaults = ['escape' => true];
         $options = is_null($options) ? [] : $options;
         $options = array_merge($defaults, $options);
         $iconDefaults = $this->config('iconDefaults');


### PR DESCRIPTION
Does anyone remember the reason that escaping of link attributes is changed to disabled by default, overriding Cake's default of `true`? It causes breaking issues when using `bin/cake bake all`...

More info here: https://github.com/cakephp/bake/pull/504