### PR TITLE
Ignore composer.lock and the vendor/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ tmp/
 Core/webroot/bootstrap/
 Core/webroot/fontAwesome/
 Core/.sass-cache/
+composer.lock
+vendor/


### PR DESCRIPTION
I guess most have global ignore for these, but I don't. Is this OK?