### PR TITLE
phpcs.xml.dist Default to CakePHP Core sniffs

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<ruleset name="CakePHP Core">
+    <config name="installed_paths" value="../../cakephp/cakephp-codesniffer" />
+
+    <rule ref="CakePHP" />
+</ruleset>


### PR DESCRIPTION
Should allow most IDE to choose correct sniffs.