### PR TITLE
Use middleware by default in tests.

### DIFF
--- a/tests/test_app/config/bootstrap.php
+++ b/tests/test_app/config/bootstrap.php
@@ -1,0 +1,2 @@
+<?php
+// Do nothing

--- a/tests/test_app/src/Application.php
+++ b/tests/test_app/src/Application.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App;
+
+use Cake\Core\Configure;
+use Cake\Core\Exception\MissingPluginException;
+use Cake\Error\Middleware\ErrorHandlerMiddleware;
+use Cake\Http\BaseApplication;
+use Cake\Routing\Middleware\AssetMiddleware;
+use Cake\Routing\Middleware\RoutingMiddleware;
+
+/**
+ * Application setup class.
+ *
+ * This defines the bootstrapping logic and middleware layers you
+ * want to use in your application.
+ *
+ * @package  Croogo.Croogo.Lib
+ * @version  1.0
+ * @author   Fahad Ibnay Heylaal <contact@fahad19.com>
+ * @license  http://www.opensource.org/licenses/mit-license.php The MIT License
+ * @link     http://www.croogo.org
+ */
+class Application extends BaseApplication
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function bootstrap(): void
+    {
+        // Call parent to load bootstrap from files.
+        parent::bootstrap();
+        if (PHP_SAPI === 'cli') {
+            $this->bootstrapCli();
+        }
+        /*
+         * Only try to load DebugKit in development mode
+         * Debug Kit should not be installed on a production system
+         */
+        if (Configure::read('debug')) {
+            $this->addPlugin('DebugKit');
+        }
+        // Load more plugins here
+    }
+
+    /**
+     * Setup the middleware queue your application will use.
+     *
+     * @param \Cake\Http\MiddlewareQueue $middlewareQueue The middleware queue to setup.
+     * @return \Cake\Http\MiddlewareQueue The updated middleware queue.
+     */
+    public function middleware($middlewareQueue): MiddlewareQueue
+    {
+        $middlewareQueue
+            // Catch any exceptions in the lower layers,
+            // and make an error page/response
+            ->add(new ErrorHandlerMiddleware(null, Configure::read('Error')))
+            // Handle plugin/theme assets like CakePHP normally does.
+            ->add(new AssetMiddleware([
+                'cacheTime' => Configure::read('Asset.cacheTime'),
+            ]))
+            // Add routing middleware.
+            // If you have a large number of routes connected, turning on routes
+            // caching in production could improve performance. For that when
+            // creating the middleware instance specify the cache config name by
+            // using it's second constructor argument:
+            // `new RoutingMiddleware($this, '_cake_routes_')`
+            ->add(new RoutingMiddleware($this));
+
+        return $middlewareQueue;
+    }
+
+    /**
+     * @return void
+     */
+    protected function bootstrapCli(): void
+    {
+        try {
+            $this->addPlugin('Bake');
+        } catch (MissingPluginException $e) {
+            // Do not halt if the plugin is missing
+        }
+        $this->addPlugin('Migrations');
+        // Load more plugins here
+    }
+}


### PR DESCRIPTION
Placing Application.php in tests/test_app/ defaults tests to use
middleware automagically. I copied Application.php from
cakephp/app@3.8.0 This addresses the deprecation message:

"Dispatcher is deprecated. You should update your application
to use the Http\Server implementation instead. -
vendor/cakephp/cakephp/src/TestSuite/LegacyRequestDispatcher.php,
line: 72"

The above message occurred for every controller/integration test (around 40 times).

tests/test_app/config/bootstrap.php is referenced in Application.php
though it doesn't do anything.

References for more info:
https://book.cakephp.org/3.0/en/development/application.html#adding-http-stack
https://github.com/cakephp/app/blob/3.8.0/src/Application.php
https://book.cakephp.org/3.0/en/appendices/3-6-migration-guide.html#deprecations
Dispatcher is mentioned on last line of the above paragraph ^