### PR TITLE
fix regex for pcre2

### DIFF
--- a/Core/src/Model/Table/CroogoTable.php
+++ b/Core/src/Model/Table/CroogoTable.php
@@ -169,7 +169,7 @@ class CroogoTable extends Table
      */
     public function validAlias($check)
     {
-        return (preg_match('/^[\p{Ll}\p{Lm}\p{Lo}\p{Lt}\p{Lu}\p{Nd}-_]+$/mu', $check[key($check)]) == 1);
+        return (preg_match('/^[-\p{Ll}\p{Lm}\p{Lo}\p{Lt}\p{Lu}\p{Nd}_]+$/mu', $check[key($check)]) == 1);
     }
 
     /**
@@ -179,6 +179,6 @@ class CroogoTable extends Table
      */
     public function validName($check)
     {
-        return (preg_match('/^[\p{Ll}\p{Lm}\p{Lo}\p{Lt}\p{Lu}\p{Nd}-_\[\]\(\) ]+$/mu', $check[key($check)]) == 1);
+        return (preg_match('/^[-\p{Ll}\p{Lm}\p{Lo}\p{Lt}\p{Lu}\p{Nd}_\[\]\(\) ]+$/mu', $check[key($check)]) == 1);
     }
 }


### PR DESCRIPTION
Resolves #922 

I see the UsersTable was already fixed between 3.0 and 4.0, so my search through the library found only one more file with offending regex's. As stated in the issue, this does not affect php 7.2 environments or earlier, only those 7.3 and later.