### PR TITLE
Fix timestamp fields

### DIFF
--- a/Blocks/config/Migrations/20191115050000_BlocksInitialMigration.php
+++ b/Blocks/config/Migrations/20191115050000_BlocksInitialMigration.php
@@ -27,7 +27,7 @@ class BlocksInitialMigration extends AbstractMigration
                 'limit' => 11,
                 'null' => false,
             ])
-            ->addTimestamps('created', 'updated')
+            ->addTimestamps('created', 'modified')
             ->addColumn('updated_by', 'integer', [
                 'default' => null,
                 'limit' => 20,
@@ -122,7 +122,7 @@ class BlocksInitialMigration extends AbstractMigration
                 'limit' => null,
                 'null' => true,
             ])
-            ->addTimestamps('created', 'updated')
+            ->addTimestamps('created', 'modified')
             ->addColumn('created_by', 'integer', [
                 'default' => null,
                 'limit' => 20,

--- a/Blocks/config/Migrations/20191115050000_BlocksInitialMigration.php
+++ b/Blocks/config/Migrations/20191115050000_BlocksInitialMigration.php
@@ -28,7 +28,7 @@ class BlocksInitialMigration extends AbstractMigration
                 'null' => false,
             ])
             ->addTimestamps('created', 'modified')
-            ->addColumn('updated_by', 'integer', [
+            ->addColumn('modified_by', 'integer', [
                 'default' => null,
                 'limit' => 20,
                 'null' => true,
@@ -128,7 +128,7 @@ class BlocksInitialMigration extends AbstractMigration
                 'limit' => 20,
                 'null' => false,
             ])
-            ->addColumn('updated_by', 'integer', [
+            ->addColumn('modified_by', 'integer', [
                 'default' => null,
                 'limit' => 20,
                 'null' => true,

--- a/Blocks/src/Model/Table/BlocksTable.php
+++ b/Blocks/src/Model/Table/BlocksTable.php
@@ -76,14 +76,7 @@ class BlocksTable extends CroogoTable
             ],
         ]);
 
-        $this->addBehavior('Timestamp', [
-            'events' => [
-                'Model.beforeSave' => [
-                    'created' => 'new',
-                    'updated' => 'always',
-                ],
-            ],
-        ]);
+        $this->addBehavior('Timestamp');
         $this->addBehavior('Croogo/Core.Trackable');
         $this->addBehavior('Search.Search');
 

--- a/Blocks/src/Model/Table/RegionsTable.php
+++ b/Blocks/src/Model/Table/RegionsTable.php
@@ -79,14 +79,7 @@ class RegionsTable extends CroogoTable
 //            ],
 //        ]);
 
-        $this->addBehavior('Timestamp', [
-            'events' => [
-                'Model.beforeSave' => [
-                    'created' => 'new',
-                    'updated' => 'always',
-                ],
-            ],
-        ]);
+        $this->addBehavior('Timestamp');
         $this->addBehavior('Croogo/Core.Trackable');
         $this->addBehavior('Search.Search');
 

--- a/Blocks/src/Template/Admin/Blocks/index.ctp
+++ b/Blocks/src/Template/Admin/Blocks/index.ctp
@@ -20,7 +20,7 @@ $tableHeaders = $this->Html->tableHeaders([
     $this->Paginator->sort('title', __d('croogo', 'Title')),
     $this->Paginator->sort('alias', __d('croogo', 'Alias')),
     $this->Paginator->sort('region_id', __d('croogo', 'Region')),
-    $this->Paginator->sort('updated', __d('croogo', 'Updated')),
+    $this->Paginator->sort('modified', __d('croogo', 'Modified')),
     $this->Paginator->sort('status', __d('croogo', 'Status')),
     __d('croogo', 'Actions'),
 ]);
@@ -92,7 +92,7 @@ foreach ($blocks as $block) {
         $title,
         $block->alias,
         $block->region->title,
-        $block->updated,
+        $block->modified,
         $this->element('Croogo/Core.admin/toggle', [
             'id' => $block->id,
             'status' => (int)$block->status,

--- a/Comments/config/Migrations/20191115050000_CommentsInitialMigration.php
+++ b/Comments/config/Migrations/20191115050000_CommentsInitialMigration.php
@@ -93,7 +93,7 @@ class CommentsInitialMigration extends AbstractMigration
                 'limit' => 11,
                 'null' => true,
             ])
-            ->addTimestamps('created', 'updated')
+            ->addTimestamps('created', 'modified')
             ->addColumn('created_by', 'integer', [
                 'default' => null,
                 'limit' => 20,

--- a/Comments/config/Migrations/20191115050000_CommentsInitialMigration.php
+++ b/Comments/config/Migrations/20191115050000_CommentsInitialMigration.php
@@ -99,7 +99,7 @@ class CommentsInitialMigration extends AbstractMigration
                 'limit' => 20,
                 'null' => true,
             ])
-            ->addColumn('updated_by', 'integer', [
+            ->addColumn('modified_by', 'integer', [
                 'default' => null,
                 'limit' => 20,
                 'null' => true,

--- a/Comments/src/Model/Table/CommentsTable.php
+++ b/Comments/src/Model/Table/CommentsTable.php
@@ -57,14 +57,7 @@ class CommentsTable extends CroogoTable
         $this->addBehavior('Croogo/Core.Cached', [
             'groups' => ['comments', 'nodes']
         ]);
-        $this->addBehavior('Timestamp', [
-            'events' => [
-                'Model.beforeSave' => [
-                    'created' => 'new',
-                    'updated' => 'always'
-                ]
-            ]
-        ]);
+        $this->addBehavior('Timestamp');
 
         $this->searchManager()
             ->add('status', 'Search.Value', [

--- a/Contacts/config/Migrations/20191115050000_ContactsInitialMigration.php
+++ b/Contacts/config/Migrations/20191115050000_ContactsInitialMigration.php
@@ -114,7 +114,7 @@ class ContactsInitialMigration extends AbstractMigration
                 'limit' => 20,
                 'null' => false,
             ])
-            ->addColumn('updated_by', 'integer', [
+            ->addColumn('modified_by', 'integer', [
                 'default' => null,
                 'limit' => 20,
                 'null' => true,
@@ -173,7 +173,7 @@ class ContactsInitialMigration extends AbstractMigration
                 'null' => false,
             ])
             ->addTimestamps('created', 'modified')
-            ->addColumn('updated_by', 'integer', [
+            ->addColumn('modified_by', 'integer', [
                 'default' => null,
                 'limit' => 20,
                 'null' => true,

--- a/Contacts/config/Migrations/20191115050000_ContactsInitialMigration.php
+++ b/Contacts/config/Migrations/20191115050000_ContactsInitialMigration.php
@@ -108,7 +108,7 @@ class ContactsInitialMigration extends AbstractMigration
                 'limit' => null,
                 'null' => false,
             ])
-            ->addTimestamps('created', 'updated')
+            ->addTimestamps('created', 'modified')
             ->addColumn('created_by', 'integer', [
                 'default' => null,
                 'limit' => 20,
@@ -172,7 +172,7 @@ class ContactsInitialMigration extends AbstractMigration
                 'limit' => null,
                 'null' => false,
             ])
-            ->addTimestamps('created', 'updated')
+            ->addTimestamps('created', 'modified')
             ->addColumn('updated_by', 'integer', [
                 'default' => null,
                 'limit' => 20,

--- a/Contacts/src/Model/Table/ContactsTable.php
+++ b/Contacts/src/Model/Table/ContactsTable.php
@@ -54,14 +54,7 @@ class ContactsTable extends CroogoTable
             'groups' => ['contacts']
         ]);
         $this->addBehavior('Croogo/Core.Trackable');
-        $this->addBehavior('Timestamp', [
-            'events' => [
-                'Model.beforeSave' => [
-                    'created' => 'new',
-                    'updated' => 'always',
-                ],
-            ],
-        ]);
+        $this->addBehavior('Timestamp');
         $this->addBehavior('Search.Search');
     }
 

--- a/Contacts/src/Model/Table/MessagesTable.php
+++ b/Contacts/src/Model/Table/MessagesTable.php
@@ -37,14 +37,7 @@ class MessagesTable extends CroogoTable
         ]);
         $this->addBehavior('Croogo/Core.Trackable');
         $this->addBehavior('Search.Search');
-        $this->addBehavior('Timestamp', [
-            'events' => [
-                'Model.beforeSave' => [
-                    'created' => 'new',
-                    'updated' => 'always'
-                ]
-            ]
-        ]);
+        $this->addBehavior('Timestamp');
 
         $this->searchManager()
             ->value('contact_id')

--- a/Contacts/src/Template/Admin/Messages/view.ctp
+++ b/Contacts/src/Template/Admin/Messages/view.ctp
@@ -56,8 +56,8 @@ $this->append('main');
             <td><?= $this->Number->format($message->id) ?></td>
         </tr>
         <tr>
-            <th scope="row"><?= __d('croogo', 'Updated') ?></th>
-            <td><?= $this->Time->i18nFormat($message->updated) ?></td>
+            <th scope="row"><?= __d('croogo', 'Modified') ?></th>
+            <td><?= $this->Time->i18nFormat($message->modified) ?></td>
         </tr>
         <tr>
             <th scope="row"><?= __d('croogo', 'Created') ?></th>

--- a/Core/src/Model/Behavior/TrackableBehavior.php
+++ b/Core/src/Model/Behavior/TrackableBehavior.php
@@ -13,7 +13,7 @@ use const PHP_SESSION_ACTIVE;
 /**
  * Trackable Behavior
  *
- * Populate `created_by` and `updated_by` fields from session data.
+ * Populate `created_by` and `modified_by` fields from session data.
  *
  * @package  Croogo.Croogo.Model.Behavior
  * @since    1.6
@@ -31,7 +31,7 @@ class TrackableBehavior extends Behavior
         'userModel' => 'Croogo/Users.Users',
         'fields' => [
             'created_by' => 'created_by',
-            'updated_by' => 'updated_by',
+            'modified_by' => 'modified_by',
             ],
         ];
 
@@ -64,7 +64,7 @@ class TrackableBehavior extends Behavior
         $fields = $this->getConfig('fields');
 
         return $this->_table->hasField($fields['created_by']) &&
-            $this->_table->hasField($fields['updated_by']);
+            $this->_table->hasField($fields['modified_by']);
     }
 
     /**
@@ -85,16 +85,16 @@ class TrackableBehavior extends Behavior
                 ],
                 'TrackableUpdater' => [
                     'className' => $config['userModel'],
-                    'foreignKey' => $config['fields']['updated_by'],
+                    'foreignKey' => $config['fields']['modified_by'],
                 ],
             ],
         ]);
     }
 
     /**
-     * Fill the created_by and updated_by fields
+     * Fill the created_by and modified_by fields
      *
-     * Note: Since shells do not have Sessions, created_by/updated_by fields
+     * Note: Since shells do not have Sessions, created_by/modified_by fields
      * will not be populated. If a shell needs to populate these fields, you
      * can simulate a logged in user by setting `Trackable.Auth` config:
      *
@@ -127,7 +127,7 @@ class TrackableBehavior extends Behavior
         }
 
         $createdByField = $config['fields']['created_by'];
-        $updatedByField = $config['fields']['updated_by'];
+        $updatedByField = $config['fields']['modified_by'];
 
         $entity = $event->getData('entity');
         if (empty($entity->{$createdByField})) {

--- a/Dashboards/config/Migrations/20160807105058_DashboardsInitialMigration.php
+++ b/Dashboards/config/Migrations/20160807105058_DashboardsInitialMigration.php
@@ -38,7 +38,7 @@ class DashboardsInitialMigration extends AbstractMigration
                 'limit' => null,
                 'null' => false,
             ])
-            ->addTimestamps('created', 'updated')
+            ->addTimestamps('created', 'modified')
             ->addForeignKey('user_id', 'users', ['id'], [
                 'constraint' => 'fk_dashboards2users',
                 'delete' => 'RESTRICT',

--- a/Dashboards/src/Template/Admin/Dashboards/index.ctp
+++ b/Dashboards/src/Template/Admin/Dashboards/index.ctp
@@ -15,7 +15,7 @@ $this->append('table-heading');
         $this->Paginator->sort('column'),
         $this->Paginator->sort('collapsed'),
         $this->Paginator->sort('status'),
-        $this->Paginator->sort('updated'),
+        $this->Paginator->sort('modified'),
         $this->Paginator->sort('created'),
         __d('croogo', 'Actions'),
     ]);
@@ -44,7 +44,7 @@ $this->append('table-heading');
                 ]);
             ?>
         </td>
-        <td><?= $this->Time->i18nFormat($dashboard->updated) ?>&nbsp;</td>
+        <td><?= $this->Time->i18nFormat($dashboard->modified) ?>&nbsp;</td>
         <td><?= $this->Time->i18nFormat($dashboard->created) ?>&nbsp;</td>
         <td class="item-actions">
             <?php

--- a/FileManager/config/Migrations/20191115050000_FileManagerInitialMigration.php
+++ b/FileManager/config/Migrations/20191115050000_FileManagerInitialMigration.php
@@ -43,7 +43,7 @@ class FileManagerInitialMigration extends AbstractMigration
             ->addColumn('asset_count', 'integer', [
                 'null' => true,
             ])
-            ->addTimestamps('created', 'updated')
+            ->addTimestamps('created', 'modified')
             ->addColumn('created_by', 'integer', [
                 'null' => true,
             ])
@@ -94,7 +94,7 @@ class FileManagerInitialMigration extends AbstractMigration
                 'null' => true, 'default' => null, 'length' => 32,
                 'comment' => 'Gaufrette Storage Adapter Class',
             ])
-            ->addTimestamps('created', 'updated')
+            ->addTimestamps('created', 'modified')
             ->addIndex(['hash', 'path'], [
                 'name' => 'ix_assets_hash',
             ])
@@ -123,7 +123,7 @@ class FileManagerInitialMigration extends AbstractMigration
             ->addColumn('url', 'string', [
                 'length' => 512, 'null' => true,
             ])
-            ->addTimestamps('created', 'updated')
+            ->addTimestamps('created', 'modified')
             ->addColumn('params', 'text', [
                 'null' => true, 'default' => null,
             ])

--- a/FileManager/config/Migrations/20191115050000_FileManagerInitialMigration.php
+++ b/FileManager/config/Migrations/20191115050000_FileManagerInitialMigration.php
@@ -47,7 +47,7 @@ class FileManagerInitialMigration extends AbstractMigration
             ->addColumn('created_by', 'integer', [
                 'null' => true,
             ])
-            ->addColumn('updated_by', 'integer', [
+            ->addColumn('modified_by', 'integer', [
                 'null' => true,
             ])
             ->addIndex(['hash'], [

--- a/FileManager/src/Model/Table/AttachmentsTable.php
+++ b/FileManager/src/Model/Table/AttachmentsTable.php
@@ -341,7 +341,7 @@ class AttachmentsTable extends CroogoTable
             'hash' => $hash,
             'status' => true,
             'created' => date('Y-m-d H:i:s', $stat[9]),
-            'updated' => date('Y-m-d H:i:s', time()),
+            'modified' => date('Y-m-d H:i:s', time()),
         ]);
 
         return $attachment;

--- a/Menus/config/Migrations/20191115050000_MenusInitialMigration.php
+++ b/Menus/config/Migrations/20191115050000_MenusInitialMigration.php
@@ -63,7 +63,7 @@ class MenusInitialMigration extends AbstractMigration
                 'limit' => 20,
                 'null' => false,
             ])
-            ->addColumn('updated_by', 'integer', [
+            ->addColumn('modified_by', 'integer', [
                 'default' => null,
                 'limit' => 20,
                 'null' => true,
@@ -161,7 +161,7 @@ class MenusInitialMigration extends AbstractMigration
                 'limit' => 20,
                 'null' => false,
             ])
-            ->addColumn('updated_by', 'integer', [
+            ->addColumn('modified_by', 'integer', [
                 'default' => null,
                 'limit' => 20,
                 'null' => true,

--- a/Menus/config/Migrations/20191115050000_MenusInitialMigration.php
+++ b/Menus/config/Migrations/20191115050000_MenusInitialMigration.php
@@ -57,7 +57,7 @@ class MenusInitialMigration extends AbstractMigration
                 'limit' => null,
                 'null' => true,
             ])
-            ->addTimestamps('created', 'updated')
+            ->addTimestamps('created', 'modified')
             ->addColumn('created_by', 'integer', [
                 'default' => null,
                 'limit' => 20,
@@ -155,7 +155,7 @@ class MenusInitialMigration extends AbstractMigration
                 'limit' => null,
                 'null' => true,
             ])
-            ->addTimestamps('created', 'updated')
+            ->addTimestamps('created', 'modified')
             ->addColumn('created_by', 'integer', [
                 'default' => null,
                 'limit' => 20,

--- a/Menus/src/Model/Table/LinksTable.php
+++ b/Menus/src/Model/Table/LinksTable.php
@@ -51,14 +51,7 @@ class LinksTable extends CroogoTable
             'Menus' => ['link_count'],
         ]);
 
-        $this->addBehavior('Timestamp', [
-            'events' => [
-                'Model.beforeSave' => [
-                    'created' => 'new',
-                    'updated' => 'always',
-                ],
-            ],
-        ]);
+        $this->addBehavior('Timestamp');
 
         $this->addBehavior('Croogo/Core.Publishable');
         $this->addBehavior('Croogo/Core.Visibility');

--- a/Menus/src/Model/Table/MenusTable.php
+++ b/Menus/src/Model/Table/MenusTable.php
@@ -53,14 +53,7 @@ class MenusTable extends CroogoTable
         $this->addBehavior('Croogo/Core.Publishable');
         $this->addBehavior('Croogo/Core.Trackable');
 
-        $this->addBehavior('Timestamp', [
-            'events' => [
-                'Model.beforeSave' => [
-                    'created' => 'new',
-                    'updated' => 'always'
-                ]
-            ]
-        ]);
+        $this->addBehavior('Timestamp');
         $this->addBehavior('Search.Search');
 
         $this->hasMany('Links', [

--- a/Menus/src/Test/Fixture/LinkFixture.php
+++ b/Menus/src/Test/Fixture/LinkFixture.php
@@ -26,7 +26,7 @@ class LinkFixture extends CroogoTestFixture
         'params' => ['type' => 'text', 'null' => true, 'default' => null],
         'publish_start' => ['type' => 'datetime', 'null' => true, 'default' => null],
         'publish_end' => ['type' => 'datetime', 'null' => true, 'default' => null],
-        'updated' => ['type' => 'datetime', 'null' => false, 'default' => null],
+        'modified' => ['type' => 'datetime', 'null' => false, 'default' => null],
         'created' => ['type' => 'datetime', 'null' => false, 'default' => null],
         '_constraints' => [
             'primary' => ['type' => 'primary', 'columns' => ['id']],
@@ -50,7 +50,7 @@ class LinkFixture extends CroogoTestFixture
             'rght' => 4,
             'visibility_roles' => '',
             'params' => '',
-            'updated' => '2009-10-06 23:14:21',
+            'modified' => '2009-10-06 23:14:21',
             'created' => '2009-08-19 12:23:33'
         ],
         [
@@ -68,7 +68,7 @@ class LinkFixture extends CroogoTestFixture
             'rght' => 6,
             'visibility_roles' => '',
             'params' => '',
-            'updated' => '2009-10-06 23:14:45',
+            'modified' => '2009-10-06 23:14:45',
             'created' => '2009-08-19 12:34:56'
         ],
         [
@@ -86,7 +86,7 @@ class LinkFixture extends CroogoTestFixture
             'rght' => 2,
             'visibility_roles' => '',
             'params' => '',
-            'updated' => '2009-10-06 21:17:06',
+            'modified' => '2009-10-06 21:17:06',
             'created' => '2009-09-06 21:32:54'
         ],
         [
@@ -104,7 +104,7 @@ class LinkFixture extends CroogoTestFixture
             'rght' => 6,
             'visibility_roles' => '',
             'params' => '',
-            'updated' => '2009-09-12 03:45:53',
+            'modified' => '2009-09-12 03:45:53',
             'created' => '2009-09-06 21:34:57'
         ],
         [
@@ -122,7 +122,7 @@ class LinkFixture extends CroogoTestFixture
             'rght' => 5,
             'visibility_roles' => '',
             'params' => '',
-            'updated' => '2009-10-06 23:13:06',
+            'modified' => '2009-10-06 23:13:06',
             'created' => '2009-09-12 03:52:23'
         ],
         [
@@ -140,7 +140,7 @@ class LinkFixture extends CroogoTestFixture
             'rght' => 2,
             'visibility_roles' => '',
             'params' => '',
-            'updated' => '2009-09-12 06:34:09',
+            'modified' => '2009-09-12 06:34:09',
             'created' => '2009-09-12 06:34:09'
         ],
         [
@@ -158,7 +158,7 @@ class LinkFixture extends CroogoTestFixture
             'rght' => 8,
             'visibility_roles' => '[\"1\",\"2\"]',
             'params' => '',
-            'updated' => '2009-09-12 06:35:22',
+            'modified' => '2009-09-12 06:35:22',
             'created' => '2009-09-12 06:34:41'
         ],
         [
@@ -176,7 +176,7 @@ class LinkFixture extends CroogoTestFixture
             'rght' => 4,
             'visibility_roles' => '',
             'params' => '',
-            'updated' => '2009-09-12 23:31:59',
+            'modified' => '2009-09-12 23:31:59',
             'created' => '2009-09-12 23:31:59'
         ],
         [
@@ -194,7 +194,7 @@ class LinkFixture extends CroogoTestFixture
             'rght' => 2,
             'visibility_roles' => '',
             'params' => '',
-            'updated' => '2009-10-07 03:25:25',
+            'modified' => '2009-10-07 03:25:25',
             'created' => '2009-09-12 23:38:43'
         ],
         [
@@ -212,7 +212,7 @@ class LinkFixture extends CroogoTestFixture
             'rght' => 8,
             'visibility_roles' => '',
             'params' => '',
-            'updated' => '2009-09-16 07:54:13',
+            'modified' => '2009-09-16 07:54:13',
             'created' => '2009-09-16 07:53:33'
         ],
         [
@@ -230,7 +230,7 @@ class LinkFixture extends CroogoTestFixture
             'rght' => 4,
             'visibility_roles' => '',
             'params' => '',
-            'updated' => '2009-10-27 17:46:22',
+            'modified' => '2009-10-27 17:46:22',
             'created' => '2009-10-27 17:46:22'
         ],
         [
@@ -248,7 +248,7 @@ class LinkFixture extends CroogoTestFixture
             'rght' => 6,
             'visibility_roles' => '',
             'params' => '',
-            'updated' => '2009-10-27 17:46:54',
+            'modified' => '2009-10-27 17:46:54',
             'created' => '2009-10-27 17:46:54'
         ],
         [
@@ -266,7 +266,7 @@ class LinkFixture extends CroogoTestFixture
             'rght' => 8,
             'visibility_roles' => '["3"]',
             'params' => '',
-            'updated' => '2009-10-27 17:46:54',
+            'modified' => '2009-10-27 17:46:54',
             'created' => '2009-10-27 17:46:54'
         ],
     ];

--- a/Menus/src/Test/Fixture/MenuFixture.php
+++ b/Menus/src/Test/Fixture/MenuFixture.php
@@ -20,7 +20,7 @@ class MenuFixture extends CroogoTestFixture
         'params' => ['type' => 'text', 'null' => true, 'default' => null],
         'publish_start' => ['type' => 'datetime', 'null' => true, 'default' => null],
         'publish_end' => ['type' => 'datetime', 'null' => true, 'default' => null],
-        'updated' => ['type' => 'datetime', 'null' => false, 'default' => null],
+        'modified' => ['type' => 'datetime', 'null' => false, 'default' => null],
         'created' => ['type' => 'datetime', 'null' => false, 'default' => null],
         '_constraints' => [
             'primary' => ['type' => 'primary', 'columns' => ['id']],
@@ -39,7 +39,7 @@ class MenuFixture extends CroogoTestFixture
             'weight' => null,
             'link_count' => 4,
             'params' => '',
-            'updated' => '2009-08-19 12:21:06',
+            'modified' => '2009-08-19 12:21:06',
             'created' => '2009-07-22 01:49:53'
         ],
         [
@@ -51,7 +51,7 @@ class MenuFixture extends CroogoTestFixture
             'weight' => null,
             'link_count' => 2,
             'params' => '',
-            'updated' => '2009-08-19 12:22:42',
+            'modified' => '2009-08-19 12:22:42',
             'created' => '2009-08-19 12:22:42'
         ],
         [
@@ -63,7 +63,7 @@ class MenuFixture extends CroogoTestFixture
             'weight' => null,
             'link_count' => 4,
             'params' => '',
-            'updated' => '2009-09-12 06:33:29',
+            'modified' => '2009-09-12 06:33:29',
             'created' => '2009-09-12 06:33:29'
         ],
         [
@@ -75,7 +75,7 @@ class MenuFixture extends CroogoTestFixture
             'weight' => null,
             'link_count' => 2,
             'params' => '',
-            'updated' => '2009-09-12 23:30:24',
+            'modified' => '2009-09-12 23:30:24',
             'created' => '2009-09-12 23:30:24'
         ],
     ];

--- a/Meta/config/Migrations/20191115050000_MetaInitialMigration.php
+++ b/Meta/config/Migrations/20191115050000_MetaInitialMigration.php
@@ -33,7 +33,7 @@ class MetaInitialMigration extends AbstractMigration
                 'limit' => 11,
                 'null' => true,
             ])
-            ->addTimestamps('created', 'updated')
+            ->addTimestamps('created', 'modified')
             ->addColumn('created_by', 'integer', [
                 'default' => null,
                 'limit' => 20,

--- a/Meta/config/Migrations/20191115050000_MetaInitialMigration.php
+++ b/Meta/config/Migrations/20191115050000_MetaInitialMigration.php
@@ -39,7 +39,7 @@ class MetaInitialMigration extends AbstractMigration
                 'limit' => 20,
                 'null' => false,
             ])
-            ->addColumn('updated_by', 'integer', [
+            ->addColumn('modified_by', 'integer', [
                 'default' => null,
                 'limit' => 20,
                 'null' => true,

--- a/Nodes/config/Migrations/20191115050000_NodesInitialMigration.php
+++ b/Nodes/config/Migrations/20191115050000_NodesInitialMigration.php
@@ -103,7 +103,7 @@ class NodesInitialMigration extends AbstractMigration
                 'limit' => 11,
                 'null' => false,
             ])
-            ->addColumn('updated_by', 'integer', [
+            ->addColumn('modified_by', 'integer', [
                 'default' => null,
                 'limit' => 11,
                 'null' => true,

--- a/Nodes/config/Migrations/20191115050000_NodesInitialMigration.php
+++ b/Nodes/config/Migrations/20191115050000_NodesInitialMigration.php
@@ -118,7 +118,7 @@ class NodesInitialMigration extends AbstractMigration
                 'limit' => null,
                 'null' => true,
             ])
-            ->addTimestamps('created', 'updated')
+            ->addTimestamps('created', 'modified')
             ->addForeignKey('user_id', 'users', ['id'], [
                 'constraint' => 'fk_nodes2users',
                 'delete' => 'RESTRICT',

--- a/Nodes/src/Model/Table/NodesTable.php
+++ b/Nodes/src/Model/Table/NodesTable.php
@@ -43,14 +43,7 @@ class NodesTable extends CroogoTable
             'groups' => ['nodes']
         ]);
         $this->addBehavior('Search.Search');
-        $this->addBehavior('Timestamp', [
-            'events' => [
-                'Model.beforeSave' => [
-                    'created' => 'new',
-                    'updated' => 'always',
-                ],
-            ],
-        ]);
+        $this->addBehavior('Timestamp');
         $this->addBehavior('Croogo/Core.Copyable', [
             'stripFields' => [
                 'model_taxonomies',

--- a/Nodes/src/Template/Admin/Nodes/index.ctp
+++ b/Nodes/src/Template/Admin/Nodes/index.ctp
@@ -43,7 +43,7 @@ echo $this->Html->tableHeaders([
     $this->Paginator->sort('title', __d('croogo', 'Title')),
     $this->Paginator->sort('type', __d('croogo', 'Type')),
     $this->Paginator->sort('user_id', __d('croogo', 'User')),
-    $this->Paginator->sort('updated', __d('croogo', 'Updated')),
+    $this->Paginator->sort('modified', __d('croogo', 'Modified')),
     $this->Paginator->sort('status', __d('croogo', 'Status')),
     '',
 ]);
@@ -89,7 +89,7 @@ $this->append('table-body');
                 <?= $node->user->username ?>
             </td>
             <td>
-                <?= $this->Time->i18nFormat($node->updated) ?>
+                <?= $this->Time->i18nFormat($node->modified) ?>
             </td>
             <td>
                 <?php

--- a/Settings/config/Migrations/20191115050000_SettingsInitialMigration.php
+++ b/Settings/config/Migrations/20191115050000_SettingsInitialMigration.php
@@ -44,7 +44,7 @@ class SettingsInitialMigration extends AbstractMigration
                 'limit' => 20,
                 'null' => false,
             ])
-            ->addColumn('updated_by', 'integer', [
+            ->addColumn('modified_by', 'integer', [
                 'default' => null,
                 'limit' => 20,
                 'null' => true,
@@ -102,7 +102,7 @@ class SettingsInitialMigration extends AbstractMigration
                 'limit' => 20,
                 'null' => false,
             ])
-            ->addColumn('updated_by', 'integer', [
+            ->addColumn('modified_by', 'integer', [
                 'default' => null,
                 'limit' => 20,
                 'null' => true,

--- a/Settings/config/Migrations/20191115050000_SettingsInitialMigration.php
+++ b/Settings/config/Migrations/20191115050000_SettingsInitialMigration.php
@@ -38,7 +38,7 @@ class SettingsInitialMigration extends AbstractMigration
                 'limit' => 11,
                 'null' => true,
             ])
-            ->addTimestamps('created', 'updated')
+            ->addTimestamps('created', 'modified')
             ->addColumn('created_by', 'integer', [
                 'default' => null,
                 'limit' => 20,
@@ -96,7 +96,7 @@ class SettingsInitialMigration extends AbstractMigration
                 'limit' => null,
                 'null' => false,
             ])
-            ->addTimestamps('created', 'updated')
+            ->addTimestamps('created', 'modified')
             ->addColumn('created_by', 'integer', [
                 'default' => null,
                 'limit' => 20,

--- a/Taxonomy/config/Migrations/20191115050000_TaxonomyInitialMigration.php
+++ b/Taxonomy/config/Migrations/20191115050000_TaxonomyInitialMigration.php
@@ -27,7 +27,7 @@ class TaxonomyInitialMigration extends AbstractMigration
                 'limit' => null,
                 'null' => true,
             ])
-            ->addTimestamps('created', 'updated')
+            ->addTimestamps('created', 'modified')
             ->addColumn('created_by', 'integer', [
                 'default' => null,
                 'limit' => 20,
@@ -90,7 +90,7 @@ class TaxonomyInitialMigration extends AbstractMigration
                 'limit' => 11,
                 'null' => true,
             ])
-            ->addTimestamps('created', 'updated')
+            ->addTimestamps('created', 'modified')
             ->addColumn('created_by', 'integer', [
                 'default' => null,
                 'limit' => 20,
@@ -138,7 +138,7 @@ class TaxonomyInitialMigration extends AbstractMigration
                 'limit' => 11,
                 'null' => true,
             ])
-            ->addTimestamps('created', 'updated')
+            ->addTimestamps('created', 'modified')
             ->addForeignKey('term_id', 'terms', ['id'], [
                 'constraint' => 'fk_taxonomies2terms',
                 'delete' => 'RESTRICT',
@@ -210,7 +210,7 @@ class TaxonomyInitialMigration extends AbstractMigration
                 'limit' => 255,
                 'null' => true,
             ])
-            ->addTimestamps('created', 'updated')
+            ->addTimestamps('created', 'modified')
             ->addColumn('created_by', 'integer', [
                 'default' => null,
                 'limit' => 20,
@@ -248,7 +248,7 @@ class TaxonomyInitialMigration extends AbstractMigration
                 'limit' => null,
                 'null' => true,
             ])
-            ->addTimestamps('created', 'updated')
+            ->addTimestamps('created', 'modified')
             ->addIndex(
                 [
                     'type_id', 'vocabulary_id',
@@ -273,7 +273,7 @@ class TaxonomyInitialMigration extends AbstractMigration
                 'limit' => 20,
                 'null' => false,
             ])
-            ->addTimestamps('created', 'updated')
+            ->addTimestamps('created', 'modified')
             ->addForeignKey('taxonomy_id', 'taxonomies', ['id'], [
                 'constraint' => 'fk_model_taxonomies2taxonomies',
                 'update' => 'CASCADE',

--- a/Taxonomy/config/Migrations/20191115050000_TaxonomyInitialMigration.php
+++ b/Taxonomy/config/Migrations/20191115050000_TaxonomyInitialMigration.php
@@ -33,7 +33,7 @@ class TaxonomyInitialMigration extends AbstractMigration
                 'limit' => 20,
                 'null' => false,
             ])
-            ->addColumn('updated_by', 'integer', [
+            ->addColumn('modified_by', 'integer', [
                 'default' => null,
                 'limit' => 20,
                 'null' => true,
@@ -96,7 +96,7 @@ class TaxonomyInitialMigration extends AbstractMigration
                 'limit' => 20,
                 'null' => false,
             ])
-            ->addColumn('updated_by', 'integer', [
+            ->addColumn('modified_by', 'integer', [
                 'default' => null,
                 'limit' => 20,
                 'null' => true,
@@ -216,7 +216,7 @@ class TaxonomyInitialMigration extends AbstractMigration
                 'limit' => 20,
                 'null' => false,
             ])
-            ->addColumn('updated_by', 'integer', [
+            ->addColumn('modified_by', 'integer', [
                 'default' => null,
                 'limit' => 20,
                 'null' => true,

--- a/Taxonomy/src/Model/Table/TaxonomiesTable.php
+++ b/Taxonomy/src/Model/Table/TaxonomiesTable.php
@@ -15,14 +15,7 @@ class TaxonomiesTable extends CroogoTable
         $this->belongsTo('Croogo/Taxonomy.Vocabularies');
         $this->addBehavior('Search.Search');
         $this->addBehavior('Tree');
-        $this->addBehavior('Timestamp', [
-            'events' => [
-                'Model.beforeSave' => [
-                    'created' => 'new',
-                    'updated' => 'always'
-                ]
-            ]
-        ]);
+        $this->addBehavior('Timestamp');
         $this->addBehavior('Croogo/Core.Cached', [
             'groups' => [
                 'nodes',

--- a/Taxonomy/src/Model/Table/TermsTable.php
+++ b/Taxonomy/src/Model/Table/TermsTable.php
@@ -32,14 +32,7 @@ class TermsTable extends CroogoTable
     public function initialize(array $config)
     {
         $this->addBehavior('Search.Search');
-        $this->addBehavior('Timestamp', [
-            'events' => [
-                'Model.beforeSave' => [
-                    'created' => 'new',
-                    'updated' => 'always'
-                ]
-            ]
-        ]);
+        $this->addBehavior('Timestamp');
         $this->addBehavior('Croogo/Core.Trackable');
 
         $this->belongsToMany('Croogo/Taxonomy.Vocabularies', [

--- a/Taxonomy/src/Model/Table/TypesTable.php
+++ b/Taxonomy/src/Model/Table/TypesTable.php
@@ -32,14 +32,7 @@ class TypesTable extends CroogoTable
 
     public function initialize(array $config)
     {
-        $this->addBehavior('Timestamp', [
-            'events' => [
-                'Model.beforeSave' => [
-                    'created' => 'new',
-                    'updated' => 'always'
-                ]
-            ]
-        ]);
+        $this->addBehavior('Timestamp');
         $this->addBehavior('Croogo/Core.Url', [
             'url' => [
                 'plugin' => 'Croogo/Nodes',

--- a/Taxonomy/src/Model/Table/VocabulariesTable.php
+++ b/Taxonomy/src/Model/Table/VocabulariesTable.php
@@ -18,14 +18,7 @@ class VocabulariesTable extends CroogoTable
             'order' => 'weight',
         ]);
 
-        $this->addBehavior('Timestamp', [
-            'events' => [
-                'Model.beforeSave' => [
-                    'created' => 'new',
-                    'updated' => 'always'
-                ]
-            ]
-        ]);
+        $this->addBehavior('Timestamp');
         $this->addBehavior('Search.Search');
         $this->addBehavior('Croogo/Core.Cached', [
             'groups' => ['taxonomy']

--- a/Translate/config/Migrations/20191115050000_TranslateInitialMigration.php
+++ b/Translate/config/Migrations/20191115050000_TranslateInitialMigration.php
@@ -48,7 +48,7 @@ class TranslateInitialMigration extends AbstractMigration
                 'limit' => 20,
                 'null' => false,
             ])
-            ->addColumn('updated_by', 'integer', [
+            ->addColumn('modified_by', 'integer', [
                 'default' => null,
                 'limit' => 20,
                 'null' => true,

--- a/Translate/config/Migrations/20191115050000_TranslateInitialMigration.php
+++ b/Translate/config/Migrations/20191115050000_TranslateInitialMigration.php
@@ -42,7 +42,7 @@ class TranslateInitialMigration extends AbstractMigration
                 'limit' => null,
                 'null' => true,
             ])
-            ->addTimestamps('created', 'updated')
+            ->addTimestamps('created', 'modified')
             ->addColumn('created_by', 'integer', [
                 'default' => null,
                 'limit' => 20,

--- a/Users/config/Migrations/20191115050000_UsersInitialMigration.php
+++ b/Users/config/Migrations/20191115050000_UsersInitialMigration.php
@@ -24,7 +24,7 @@ class UsersInitialMigration extends AbstractMigration
                 'limit' => 20,
                 'null' => false,
             ])
-            ->addColumn('updated_by', 'integer', [
+            ->addColumn('modified_by', 'integer', [
                 'default' => null,
                 'limit' => 20,
                 'null' => true,
@@ -99,7 +99,7 @@ class UsersInitialMigration extends AbstractMigration
                 'limit' => 20,
                 'null' => false,
             ])
-            ->addColumn('updated_by', 'integer', [
+            ->addColumn('modified_by', 'integer', [
                 'default' => null,
                 'limit' => 20,
                 'null' => true,

--- a/Users/config/Migrations/20191115050000_UsersInitialMigration.php
+++ b/Users/config/Migrations/20191115050000_UsersInitialMigration.php
@@ -18,7 +18,7 @@ class UsersInitialMigration extends AbstractMigration
                 'limit' => 100,
                 'null' => true,
             ])
-            ->addTimestamps('created', 'updated')
+            ->addTimestamps('created', 'modified')
             ->addColumn('created_by', 'integer', [
                 'default' => null,
                 'limit' => 20,
@@ -93,7 +93,7 @@ class UsersInitialMigration extends AbstractMigration
                 'limit' => 40,
                 'null' => false,
             ])
-            ->addTimestamps('created', 'updated')
+            ->addTimestamps('created', 'modified')
             ->addColumn('created_by', 'integer', [
                 'default' => null,
                 'limit' => 20,
@@ -126,7 +126,7 @@ class UsersInitialMigration extends AbstractMigration
                 'limit' => 11,
                 'null' => true,
             ])
-            ->addTimestamps('created', 'updated')
+            ->addTimestamps('created', 'modified')
             ->addForeignKey('user_id', 'users', ['id'], [
                 'constraint' => 'fk_roles_users2users',
                 'delete' => 'RESTRICT',

--- a/Users/src/Controller/Admin/UsersController.php
+++ b/Users/src/Controller/Admin/UsersController.php
@@ -307,7 +307,7 @@ class UsersController extends AppController
                 'timezone',
                 'status',
                 'created',
-                'updated',
+                'modified',
             ])
             ->contain([
             'Roles' => [

--- a/Users/src/Model/Table/UsersTable.php
+++ b/Users/src/Model/Table/UsersTable.php
@@ -57,14 +57,7 @@ class UsersTable extends CroogoTable
             'type' => 'requester'
         ]);
         $this->addBehavior('Search.Search');
-        $this->addBehavior('Timestamp', [
-            'events' => [
-                'Model.beforeSave' => [
-                    'created' => 'new',
-                    'updated' => 'always'
-                ]
-            ]
-        ]);
+        $this->addBehavior('Timestamp');
         $this->addBehavior('Croogo/Core.Cached', [
             'groups' => ['users']
         ]);

--- a/Users/src/Template/Admin/Users/view.ctp
+++ b/Users/src/Template/Admin/Users/view.ctp
@@ -39,16 +39,16 @@ $this->append('main');
             <td><?= h($user->timezone) ?></td>
         </tr>
         <tr>
-            <th scope="row"><?= __d('croogo', 'Updated By') ?></th>
-            <td><?= $this->Number->format($user->updated_by) ?></td>
+            <th scope="row"><?= __d('croogo', 'Modified By') ?></th>
+            <td><?= $this->Number->format($user->modified_by) ?></td>
         </tr>
         <tr>
             <th scope="row"><?= __d('croogo', 'Created By') ?></th>
             <td><?= $this->Number->format($user->created_by) ?></td>
         </tr>
         <tr>
-            <th scope="row"><?= __d('croogo', 'Updated') ?></th>
-            <td><?= $this->Time->i18nFormat($user->updated) ?></td>
+            <th scope="row"><?= __d('croogo', 'Modified') ?></th>
+            <td><?= $this->Time->i18nFormat($user->modified) ?></td>
         </tr>
         <tr>
             <th scope="row"><?= __d('croogo', 'Created') ?></th>


### PR DESCRIPTION
We are starting anew with db migrations due to foreign keys in croogo 4.x, we should take this opportunity to update these fields to follow cakephp's default.