### PR TITLE
Install: Catch all exceptions including missing database

### DIFF
--- a/Core/src/PluginManager.php
+++ b/Core/src/PluginManager.php
@@ -1296,7 +1296,7 @@ class PluginManager extends Plugin
         Configure::config('settings', new DatabaseConfig());
         try {
             Configure::load('settings', 'settings');
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             Log::error($e->getMessage());
             Log::error('You can ignore the above error during installation');
         }


### PR DESCRIPTION
During CLI installation, the missing database would prevent settings from being loaded properly, causing the installation process to stop. Catching the PdoException and ignoring it during installation allows the process to continue.