### PR TITLE
Remove fake baked phinx associations

### DIFF
--- a/Core/config/bootstrap.php
+++ b/Core/config/bootstrap.php
@@ -3,12 +3,26 @@
 use Cake\Event\Event;
 use Cake\Event\EventManager;
 
-// When baking models, use the Cake standard table template,
-// but include the Search behavior in all models.
+// When baking models, use the Cake standard table template, but also;
+//   include the Search behavior, and
+//   remove the Phinxlog association if present
+//     this shows up in models with the same name as their plugin
+//     after a Phinx migration has been run
 EventManager::instance()->on(
     'Bake.beforeRender.Model.table',
     function (Event $event) {
         $view = $event->getSubject();
-        $view->set('behaviors', ['Search.Search' => []]);
+
+        $behaviors = $view->get('behaviors');
+        $behaviors['Search.Search'] = [];
+        $view->set('behaviors', $behaviors);
+
+        $associations = $view->get('associations');
+        foreach ($associations['belongsToMany'] as $key => $assoc) {
+            if ($assoc['alias'] == 'Phinxlog') {
+                unset($associations['belongsToMany'][$key]);
+                $view->set('associations', $associations);
+            }
+        }
     }
 );


### PR DESCRIPTION
When baking some plugin models after using phinx for migrations, one of the models had a bogus association to phinxlog.

For example, I'm baking a Books plugin, with a Books model and an Authors model. After migrating an initial setup of the tables, the database contains a `books_phinxlog` table to record the migrations completed. Then, when baking the Books model, bake thinks that log table is a join table and associates them with a belongsToMany. This is not what's intended, but rather an unfortunate naming standard by Phinx with respect to Cake naming standards.

So, it's only when the model name and the plugin name are the same that this should occur, but there might be some other cases that I can't foresee. In any case, it would be extremely rare that someone actually wants a phinxlog association in their model, so simply taking it out during baking seems like the right choice.