### PR TITLE
Marked up excerpt

### DIFF
--- a/Core/src/Template/Element/masthead.ctp
+++ b/Core/src/Template/Element/masthead.ctp
@@ -6,7 +6,7 @@ $this->loadHelper('Croogo/FileManager.FileManager');
 
 if (isset($node)) :
     $mastheadTitle = $node->title;
-    $mastheadSubheading = $node->excerpt;
+    $mastheadSubheading = strip_tags($node->excerpt);
     $mastheadWrapperClass = "post-heading";
     if (isset($node->linked_assets['FeaturedImage'][0])) :
         $media = $node->linked_assets['FeaturedImage'][0];

--- a/Meta/src/View/Helper/MetaHelper.php
+++ b/Meta/src/View/Helper/MetaHelper.php
@@ -86,7 +86,7 @@ class MetaHelper extends Helper
         if ($node && !array_key_exists($key, $metaForLayout)) {
             $converter = new StringConverter();
             if (!empty($node['excerpt'])) {
-                $metaForLayout[$key] = $node['excerpt'];
+                $metaForLayout[$key] = strip_tags($node['excerpt']);
             } else {
                 $metaForLayout[$key] = $converter->firstPara($node['body']);
             }

--- a/Nodes/config/bootstrap.php
+++ b/Nodes/config/bootstrap.php
@@ -30,15 +30,24 @@ Wysiwyg::setActions([
         [
             'elements' => '#NodeBody',
         ],
+        [
+            'elements' => '#NodeExcerpt',
+        ],
     ],
     'Croogo/Nodes.Admin/Nodes/edit' => [
         [
             'elements' => '#NodeBody',
         ],
+        [
+            'elements' => '#NodeExcerpt',
+        ],
     ],
     'Croogo/Translate.Admin/Translate/edit' => [
         [
             'elements' => "[id^='translations'][id$='body']",
+        ],
+        [
+            'elements' => "[id^='translations'][id$='excerpt']",
         ],
     ],
 ]);

--- a/Nodes/src/Template/Admin/Nodes/form.ctp
+++ b/Nodes/src/Template/Admin/Nodes/form.ctp
@@ -64,6 +64,7 @@ $this->start('tab-content');
         ]);
         echo $this->Form->input('excerpt', [
             'label' => __d('croogo', 'Excerpt'),
+            'id' => 'NodeExcerpt',
         ]);
         echo $this->Html->tabEnd();
         $this->end();


### PR DESCRIPTION
Closes #969.

The main change is that Nodes.Excerpt will now be a marked up field instead of text only. Custom production code assuming excerpt is text may now need to strip_tags. Existing Core code using excerpt has been updated as part of this PR.